### PR TITLE
feature-12-mdcodes-service

### DIFF
--- a/app/services/codelist.js
+++ b/app/services/codelist.js
@@ -1,0 +1,25 @@
+import Ember from 'ember';
+import codes from 'npm:mdcodes/resources/js/mdcodes.js';
+/**
+ * Codelist Service
+ *
+ * This service provides controlled value lists for use in the editor. The
+ * service may be customized by modifing the object passed to
+ * Ember.Service.extend. The existing property names should be maintained.
+ *
+ * @module
+ */
+
+//create a new object
+const codelist = {};
+
+//remap codelist names to be more generic
+Object.keys(codes)
+  .forEach(function (key) {
+    const list = codes[key];
+    const name = key.replace(/^iso_/, '');
+
+    codelist[name] = list;
+  });
+
+export default Ember.Service.extend(codelist);

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "license": "MIT",
   "devDependencies": {
     "broccoli-asset-rev": "^2.1.2",
+    "ember-browserify": "^1.1.4",
     "ember-cli": "1.13.8",
     "ember-cli-app-version": "0.5.0",
     "ember-cli-babel": "^5.1.3",
@@ -35,6 +36,7 @@
     "ember-cli-uglify": "^1.2.0",
     "ember-data": "1.13.8",
     "ember-disable-proxy-controllers": "^1.0.0",
-    "ember-export-application-global": "^1.0.3"
+    "ember-export-application-global": "^1.0.3",
+    "mdcodes": "^1.2.3"
   }
 }

--- a/tests/unit/services/codelist-test.js
+++ b/tests/unit/services/codelist-test.js
@@ -1,0 +1,21 @@
+import {
+  moduleFor, test
+}
+from 'ember-qunit';
+import codes from 'npm:mdcodes/resources/js/mdcodes.js';
+
+moduleFor('service:codelist', 'Unit | Service | codelist', {
+  // Specify the other units that are required for this test.
+  // needs: ['service:foo']
+});
+
+test('all codelists are present', function (assert) {
+  var service = this.subject();
+
+  Object.keys(codes)
+    .forEach(function (key) {
+      const name = key.replace(/^iso_/, '');
+
+      assert.ok(service.get(name), name + ' is present.');
+    });
+});


### PR DESCRIPTION
Add ember-browserify to support npm module imports.
Add mdcodes dependency.

Use individual codelists like this:

    import Phone from 'npm:mdcodes/resources/js/iso_telephone';

Closes #12