### PR TITLE
Feature 32 new record templates

### DIFF
--- a/app/models/contact.js
+++ b/app/models/contact.js
@@ -8,7 +8,7 @@ export default DS.Model.extend({
       var obj = {
         "contactId": UUID.v4().substr(0,6),
         "organizationName": null,
-        "individualName": "New Contact",
+        "individualName": null,
         "positionName": null,
         "phoneBook": [],
         "address": {},

--- a/app/models/contact.js
+++ b/app/models/contact.js
@@ -6,7 +6,7 @@ export default DS.Model.extend({
   json: DS.attr('json', {
     defaultValue: function() {
       var obj = {
-        "contactId": UUID.v4().substr(0,6),
+        "contactId": UUID.v4(),
         "organizationName": null,
         "individualName": null,
         "positionName": null,

--- a/app/models/contact.js
+++ b/app/models/contact.js
@@ -4,9 +4,9 @@ import UUID from "npm:node-uuid";
 
 export default DS.Model.extend({
   json: DS.attr('json', {
-    defaultValue: function () {
+    defaultValue: function() {
       var obj = {
-        "contactId": UUID.v4(),
+        "contactId": UUID.v4().substr(0,6),
         "organizationName": null,
         "individualName": "New Contact",
         "positionName": null,
@@ -18,16 +18,37 @@ export default DS.Model.extend({
       return obj;
     }
   }),
+
   title: Ember.computed('json.individualName', 'json.organizationName',
-    function () {
+    function() {
       const json = this.get('json');
 
       return json.individualName || json.organizationName;
     }),
+
   icon: Ember.computed('json.individualName', 'json.organizationName',
-    function () {
+    function() {
       const name = this.get('json.individualName');
 
       return name ? 'user' : 'users';
-    })
+    }),
+
+  combinedName: Ember.computed( 'json.individualName', 'json.organizationName', function() {
+    const json = this.get('json');
+
+    let indName = json.individualName;
+    let orgName = json.organizationName;
+    let combinedName = orgName;
+
+    if (indName && orgName) {
+      return combinedName += ": " + indName;
+    }
+
+    if (indName) {
+      return combinedName = indName;
+    }
+
+    return combinedName;
+  })
+
 });

--- a/app/models/contact.js
+++ b/app/models/contact.js
@@ -1,6 +1,7 @@
 import Ember from 'ember';
 import DS from 'ember-data';
-import UUID from "npm:node-uuid";
+import UUID from 'npm:node-uuid';
+import Validator from 'npm:validator';
 
 export default DS.Model.extend({
   json: DS.attr('json', {
@@ -49,6 +50,15 @@ export default DS.Model.extend({
     }
 
     return combinedName;
+  }),
+
+  shortId: Ember.computed('json.contactId', function() {
+    const contactId = this.get('json.contactId');
+    if (Validator.isUUID(contactId)) {
+      return contactId.substring(0,7);
+    }
+    
+    return contactId;
   })
 
 });

--- a/app/models/contact.js
+++ b/app/models/contact.js
@@ -55,7 +55,7 @@ export default DS.Model.extend({
   shortId: Ember.computed('json.contactId', function() {
     const contactId = this.get('json.contactId');
     if (Validator.isUUID(contactId)) {
-      return contactId.substring(0,7);
+      return contactId.substring(0,7) + '...';
     }
     
     return contactId;

--- a/app/models/dictionary.js
+++ b/app/models/dictionary.js
@@ -7,14 +7,14 @@ export default DS.Model.extend({
       const obj = {
         "dictionaryInfo": {
           "citation": {
-            "title": "My Dictionary",
+            "title": "New Dictionary",
             "date": [{
               "date": new Date()
                 .toISOString(),
               "dateType": "creation"
             }]
           },
-          "description": "Data dictionary.",
+          "description": "",
           "resourceType": null
         },
         "domain": [],
@@ -24,8 +24,10 @@ export default DS.Model.extend({
       return obj;
     }
   }),
+
   title: Ember.computed('json.dictionaryInfo.citation.title', function () {
     return this.get('json.dictionaryInfo.citation.title');
   }),
+
   icon: 'book'
 });

--- a/app/models/dictionary.js
+++ b/app/models/dictionary.js
@@ -7,14 +7,14 @@ export default DS.Model.extend({
       const obj = {
         "dictionaryInfo": {
           "citation": {
-            "title": "New Dictionary",
+            "title": null,
             "date": [{
               "date": new Date()
                 .toISOString(),
               "dateType": "creation"
             }]
           },
-          "description": "",
+          "description": null,
           "resourceType": null
         },
         "domain": [],

--- a/app/models/record.js
+++ b/app/models/record.js
@@ -11,32 +11,29 @@ export default DS.Model.extend({
       const obj = Ember.Object.create({
         "version": {
           "name": "mdJson",
-          "version": "1.0.0"
+          "version": "1.1.0"
         },
         "contact": [],
         "metadata": {
           "metadataInfo": {
             "metadataIdentifier": {
               "identifier": UUID.v4(),
-              "type": "uuid"
+              "type": ""
             }
           },
           "resourceInfo": {
             "resourceType": null,
             "citation": {
-              "title": "My Record",
-              "date": [{
-                "date": new Date()
-                  .toISOString(),
-                "dateType": "creation"
-              }]
+              "title": "New Record",
+              "date": []
             },
             "pointOfContact": [],
             "abstract": null,
             "status": null,
             "language": ["eng; USA"]
           }
-        }
+        },
+        "dataDictionary": []
       });
 
       return obj;
@@ -46,6 +43,7 @@ export default DS.Model.extend({
   title: Ember.computed('json.metadata.resourceInfo.citation.title', function () {
     return this.get('json.metadata.resourceInfo.citation.title');
   }),
+
   icon: Ember.computed('json.metadata.resourceInfo.resourceType', function () {
     const type = this.get('json.metadata.resourceInfo.resourceType');
     const list = Ember.getOwner(this)

--- a/app/models/record.js
+++ b/app/models/record.js
@@ -24,7 +24,7 @@ export default DS.Model.extend({
           "resourceInfo": {
             "resourceType": null,
             "citation": {
-              "title": "New Record",
+              "title": null,
               "date": []
             },
             "pointOfContact": [],

--- a/app/pods/components/input/md-codelist/component.js
+++ b/app/pods/components/input/md-codelist/component.js
@@ -38,12 +38,6 @@ export default Ember.Component.extend({
    * @type {Boolean}
    */
   allowClear: false,
-  
-  /**
-   * Whether to close select list after selection has been made
-   * @type {Boolean}
-   */
-  closeOnSelect: true,
 
   /**
    * The codelist name
@@ -128,12 +122,8 @@ export default Ember.Component.extend({
     return codelist;
   }),
 
-  /**
-   * Format options for the select tag
-   * Add tooltips,icons if requested
-   *
-   * @return {undefined}
-   */
+  // Format options for the select tag
+  // Add tooltips,icons if requested
   didInsertElement: function() {
     let tooltip = this.get('tooltip');
     let icon = this.get('icon');
@@ -177,8 +167,7 @@ export default Ember.Component.extend({
         templateResult: formatOption,
         width: this.get('width'),
         minimumResultsForSearch: 10,
-        closeOnSelect: (this.$('.md-codelist select').prop('multiple') === 'multiple') ? 
-            false : this.get('closeOnSelect'),
+        closeOnSelect: !!this.$('.md-codelist select').prop('multiple'),
         theme: 'bootstrap'
       });
   },

--- a/app/pods/components/input/md-codelist/component.js
+++ b/app/pods/components/input/md-codelist/component.js
@@ -38,6 +38,12 @@ export default Ember.Component.extend({
    * @type {Boolean}
    */
   allowClear: false,
+  
+  /**
+   * Whether to close select list after selection has been made
+   * @type {Boolean}
+   */
+  closeOnSelect: true,
 
   /**
    * The codelist name
@@ -167,7 +173,8 @@ export default Ember.Component.extend({
         templateResult: formatOption,
         width: this.get('width'),
         minimumResultsForSearch: 10,
-        closeOnSelect: !!this.$('.md-codelist select').prop('multiple'),
+        closeOnSelect: (this.$('.md-codelist select').prop('multiple') === 'multiple') ? 
+            false : this.get('closeOnSelect'),
         theme: 'bootstrap'
       });
   },

--- a/app/pods/components/input/md-codelist/component.js
+++ b/app/pods/components/input/md-codelist/component.js
@@ -38,6 +38,12 @@ export default Ember.Component.extend({
    * @type {Boolean}
    */
   allowClear: false,
+  
+  /**
+   * Whether to close select list after selection has been made
+   * @type {Boolean}
+   */
+  closeOnSelect: true,
 
   /**
    * The codelist name
@@ -171,7 +177,8 @@ export default Ember.Component.extend({
         templateResult: formatOption,
         width: this.get('width'),
         minimumResultsForSearch: 10,
-        closeOnSelect: !!this.$('.md-codelist select').prop('multiple'),
+        closeOnSelect: (this.$('.md-codelist select').prop('multiple') === 'multiple') ? 
+            false : this.get('closeOnSelect'),
         theme: 'bootstrap'
       });
   },

--- a/app/pods/contact/new/route.js
+++ b/app/pods/contact/new/route.js
@@ -32,8 +32,11 @@ export default Ember.Route.extend({
         let haveOrganization = model.get('json.organizationName') ? true : false;
       return !(haveIndividual || haveOrganization);
     });
+    controller.allowSave = Ember.computed('noId', 'noName', function () {
+      return (this.get('noName') || this.get('noId'));
+    });
   },
-
+  
   actions: {
     saveContact() {
       let haveId = !this.controller.get('noId');

--- a/app/pods/contact/new/route.js
+++ b/app/pods/contact/new/route.js
@@ -4,7 +4,8 @@ export default Ember.Route.extend({
   model: function () {
     return this.store.createRecord('contact');
   },
-  deactivate: function () {
+
+  deactivate: function() {
     // We grab the model loaded in this route
     var model = this.modelFor('contact/new');
 
@@ -13,6 +14,45 @@ export default Ember.Route.extend({
     if (model.get('isNew')) {
       // We call DS#destroyRecord() which removes it from the store
       model.destroyRecord();
+    }
+  },
+
+  //some test actions
+  setupController: function(controller, model) {
+    // Call _super for default behavior
+    this._super(controller, model);
+
+    // setup tests for required attributes
+    controller.noId = Ember.computed('model.json.contactId', function() {
+      return model.get('json.contactId') ? false : true;
+    });
+    controller.noName = Ember.computed('model.json.individualName',
+      'model.json.organizationName', function() {
+        let haveIndividual = model.get('json.individualName') ? true : false;
+        let haveOrganization = model.get('json.organizationName') ? true : false;
+      return !(haveIndividual || haveOrganization);
+    });
+  },
+
+  actions: {
+    saveContact() {
+      let haveId = !this.controller.get('noId');
+      let haveName = !this.controller.get('noName');
+      if (haveId && haveName) {
+        this.modelFor('contact.new')
+          .save()
+          .then((model) => {
+            this.transitionTo('contact.show.edit', model);
+          });
+      }
+
+      return false;
+    },
+
+    cancelContact() {
+      this.transitionTo('contacts');
+
+      return false;
     }
   }
 });

--- a/app/pods/contact/new/route.js
+++ b/app/pods/contact/new/route.js
@@ -39,19 +39,13 @@ export default Ember.Route.extend({
   
   actions: {
     saveContact() {
-      let haveId = !this.controller.get('noId');
-      let haveName = !this.controller.get('noName');
-      if (haveId && haveName) {
-        this.modelFor('contact.new')
-          .save()
-          .then((model) => {
-            this.transitionTo('contact.show.edit', model);
-          });
-      }
-
-      return false;
+      this.modelFor('contact.new')
+        .save()
+        .then((model) => {
+          this.transitionTo('contact.show.edit', model);
+        });
     },
-
+    
     cancelContact() {
       this.transitionTo('contacts');
 

--- a/app/pods/contact/new/template.hbs
+++ b/app/pods/contact/new/template.hbs
@@ -11,12 +11,12 @@
             <div class="form-group">
                 <div class="col-sm-12">
                     {{#if noId}}
-                        <div class="alert alert-danger" role="alert">
+                        <div class="alert alert-danger md-form-alert" role="alert">
                             You must provide a Contact ID for this contact.
                         </div>
                     {{/if}}
                     {{#if noName}}
-                        <div class="alert alert-danger" role="alert">
+                        <div class="alert alert-danger md-form-alert" role="alert">
                             You must either an individual or organization name.
                         </div>
                     {{/if}}
@@ -50,7 +50,7 @@
                 <div class="col-sm-offset-4 col-sm-8">
                     <button {{action "cancelContact"}} class="btn btn-warning pull-right">Cancel</button>
                     <span class="pull-right">&nbsp;</span>
-                    <button {{action "saveContact"}} class="btn btn-success pull-right"
+                    <button {{action "saveContact"}} class="btn btn-success pull-right md-form-save"
                                                      disabled={{allowSave}}>Save</button>
                 </div>
             </div>

--- a/app/pods/contact/new/template.hbs
+++ b/app/pods/contact/new/template.hbs
@@ -5,55 +5,58 @@
             individual name, organization name, or both.</p>
     </div>
 </div>
-<div class="row">
+
+<div class="container">
     <div class="col-md-6 col-md-offset-3">
-        <form class="form-horizontal">
-            <div class="form-group">
-                <div class="col-sm-12">
-                    {{#if noId}}
-                        <div class="alert alert-danger md-form-alert" role="alert">
-                            You must provide a Contact ID for this contact.
-                        </div>
-                    {{/if}}
-                    {{#if noName}}
-                        <div class="alert alert-danger md-form-alert" role="alert">
-                            You must either an individual or organization name.
-                        </div>
-                    {{/if}}
+        <div class="col-sm-12">
+            {{#if noId}}
+                <div class="alert alert-danger md-form-alert" role="alert">
+                    You must provide a Contact ID for this contact.
                 </div>
-            </div>
-            <div class="form-group">
-                <label class="col-sm-3 control-label">Contact ID</label>
-                <div class="col-sm-9">
-                    {{input/md-input
-                    value=model.json.contactId
-                    placeholder="Enter an ID for this contact"}}
+            {{/if}}
+            {{#if noName}}
+                <div class="alert alert-danger md-form-alert" role="alert">
+                    You must either an individual or organization name.
                 </div>
+            {{/if}}
+        </div>
+    </div>
+</div>
+
+<div class="container">
+    <div class="form-horizontal col-md-6 col-md-offset-3">
+        <div class="form-group">
+            <label class="col-sm-3 control-label">Contact ID</label>
+            <div class="col-sm-9">
+                {{input/md-input
+                value=model.json.contactId
+                placeholder="Enter an ID for this contact"}}
             </div>
+        </div>
+        <div class="form-group">
+            <label class="col-sm-3 control-label">Individual Name</label>
+            <div class="col-sm-9">
+                {{input/md-input
+                value=model.json.individualName
+                placeholder="Enter a name for this person"}}
+            </div>
+        </div>
             <div class="form-group">
-                <label class="col-sm-3 control-label">Individual Name</label>
-                <div class="col-sm-9">
-                    {{input/md-input
-                    value=model.json.individualName
-                    placeholder="Enter a name for this person"}}
-                </div>
+            <label class="col-sm-3 control-label">Organization Name</label>
+            <div class="col-sm-9">
+                {{input/md-input
+                value=model.json.organizationName
+                placeholder="Enter a name for this organization"}}
             </div>
-            <div class="form-group">
-                <label class="col-sm-3 control-label">Organization Name</label>
-                <div class="col-sm-9">
-                    {{input/md-input
-                    value=model.json.organizationName
-                    placeholder="Enter a name for this organization"}}
-                </div>
+        </div>
+        <div class="form-group">
+            <div class="col-sm-offset-4 col-sm-8">
+                 <span class="pull-right">
+                      <button {{action "saveContact"}} class="btn btn-success md-form-save"
+                                                       disabled={{allowSave}}>Save</button>
+                      <button {{action "cancelContact"}} class="btn btn-warning ">Cancel</button>
+                 </span>
             </div>
-            <div class="form-group">
-                <div class="col-sm-offset-4 col-sm-8">
-                    <button {{action "cancelContact"}} class="btn btn-warning pull-right">Cancel</button>
-                    <span class="pull-right">&nbsp;</span>
-                    <button {{action "saveContact"}} class="btn btn-success pull-right md-form-save"
-                                                     disabled={{allowSave}}>Save</button>
-                </div>
-            </div>
-        </form>
+        </div>
     </div>
 </div>

--- a/app/pods/contact/new/template.hbs
+++ b/app/pods/contact/new/template.hbs
@@ -1,9 +1,58 @@
-<div class="form-group">
-    <label for="input-org">Organization Name</label>
-    {{input value=model.json.organizationName placeholder="Organization Name" class="form-control" id="input-org"}}
+<div class="row text-center">
+    <div class="col-md-8 col-md-offset-2">
+        <h3>Create New Contact</h3>
+        <p class="text-center">To create a <em> new</em> contact, enter a contact ID and an
+            individual name, organization name, or both.</p>
+    </div>
 </div>
-<div class="form-group">
-    <label for="input-ind">Individual Name</label>
-    {{input value=model.json.individualName placeholder="Individual Name" class="form-control" id="input-ind"}}
+<div class="row">
+    <div class="col-md-6 col-md-offset-3">
+        <form class="form-horizontal">
+            <div class="form-group">
+                <div class="col-sm-12">
+                    {{#if noId}}
+                        <div class="alert alert-danger" role="alert">
+                            You must provide a Contact ID for this contact.
+                        </div>
+                    {{/if}}
+                    {{#if noName}}
+                        <div class="alert alert-danger" role="alert">
+                            You must either an individual or organization name.
+                        </div>
+                    {{/if}}
+                </div>
+            </div>
+            <div class="form-group">
+                <label class="col-sm-3 control-label">Contact ID</label>
+                <div class="col-sm-9">
+                    {{input/md-input
+                    value=model.json.contactId
+                    placeholder="Enter an ID for this contact"}}
+                </div>
+            </div>
+            <div class="form-group">
+                <label class="col-sm-3 control-label">Individual Name</label>
+                <div class="col-sm-9">
+                    {{input/md-input
+                    value=model.json.individualName
+                    placeholder="Enter a name for this person"}}
+                </div>
+            </div>
+            <div class="form-group">
+                <label class="col-sm-3 control-label">Organization Name</label>
+                <div class="col-sm-9">
+                    {{input/md-input
+                    value=model.json.organizationName
+                    placeholder="Enter a name for this organization"}}
+                </div>
+            </div>
+            <div class="form-group">
+                <div class="col-sm-offset-4 col-sm-8">
+                    <button {{action "cancelContact"}} class="btn btn-warning pull-right">Cancel</button>
+                    <span class="pull-right">&nbsp;</span>
+                    <button {{action "saveContact"}} class="btn btn-success pull-right">Save</button>
+                </div>
+            </div>
+        </form>
+    </div>
 </div>
-{{outlet}}

--- a/app/pods/contact/new/template.hbs
+++ b/app/pods/contact/new/template.hbs
@@ -50,7 +50,8 @@
                 <div class="col-sm-offset-4 col-sm-8">
                     <button {{action "cancelContact"}} class="btn btn-warning pull-right">Cancel</button>
                     <span class="pull-right">&nbsp;</span>
-                    <button {{action "saveContact"}} class="btn btn-success pull-right">Save</button>
+                    <button {{action "saveContact"}} class="btn btn-success pull-right"
+                                                     disabled={{allowSave}}>Save</button>
                 </div>
             </div>
         </form>

--- a/app/pods/contacts/route.js
+++ b/app/pods/contacts/route.js
@@ -7,21 +7,27 @@ export default Ember.Route.extend({
 
   actions: {
     deleteItem: function(item) {
-      if (window.confirm(
-              "Do you really want to delete this contact?\n\n" +
-              "Be sure this contact is not referenced by a metadata record or dictionary " +
-              "or it's deletion may cause those records to not validate.")) {
-        item.destroyRecord().then(function() {
-          console.log('+-- deleted contact ID:', item.id);
-        }, function() {
-          console.log('+--- delete contact failed');
-        });
-      }
+      let message =
+          "Do you really want to delete this contact?\n\n" +
+          "Be sure this contact is not referenced by a metadata record or dictionary " +
+          "or it's deletion may cause those records to not validate.";
+      this._deleteItem(item, message);
     },
 
     editItem: function(item) {
       this.transitionTo('contact.show.edit', item);
     }
+  },
+  
+  // action methods 
+  _deleteItem(item, message) {
+    if (window.confirm(message)) {
+      item.destroyRecord().then(function() {
+        console.log('+-- deleted contact ID:', item.id);
+      }, function() {
+        console.log('+-- delete contact failed');
+      });
+    }
   }
-
+  
 });

--- a/app/pods/contacts/route.js
+++ b/app/pods/contacts/route.js
@@ -22,11 +22,7 @@ export default Ember.Route.extend({
   // action methods 
   _deleteItem(item, message) {
     if (window.confirm(message)) {
-      item.destroyRecord().then(function() {
-        console.log('+-- deleted contact ID:', item.id);
-      }, function() {
-        console.log('+-- delete contact failed');
-      });
+      item.destroyRecord();
     }
   }
   

--- a/app/pods/contacts/route.js
+++ b/app/pods/contacts/route.js
@@ -1,4 +1,27 @@
 import Ember from 'ember';
 
 export default Ember.Route.extend({
+  model() {
+    return this.store.findAll('contact');
+  },
+
+  actions: {
+    deleteItem: function(item) {
+      if (window.confirm(
+              "Do you really want to delete this contact?\n\n" +
+              "Be sure this contact is not referenced by a metadata record or dictionary " +
+              "or it's deletion may cause those records to not validate.")) {
+        item.destroyRecord().then(function() {
+          console.log('+-- deleted contact ID:', item.id);
+        }, function() {
+          console.log('+--- delete contact failed');
+        });
+      }
+    },
+
+    editItem: function(item) {
+      this.transitionTo('contact.show.edit', item);
+    }
+  }
+
 });

--- a/app/pods/contacts/template.hbs
+++ b/app/pods/contacts/template.hbs
@@ -15,7 +15,7 @@
                 <tr>
                     <td>{{input type="checkbox" name="isChecked"}}</td>
                     <td>{{index}}</td>
-                    <td>{{item.json.contactId}}</td>
+                    <td>{{item.shortId}}</td>
                     <td>{{item.json.individualName}}</td>
                     <td>{{item.json.organizationName}}</td>
                     <td>

--- a/app/pods/contacts/template.hbs
+++ b/app/pods/contacts/template.hbs
@@ -1,6 +1,6 @@
 <h3>Contacts Dashboard</h3>
+
 <div class="container-fluid">
-    <br>
     <table class="table table-striped table-hover">
         <thead>
         <th></th>
@@ -11,25 +11,27 @@
         <th></th>
         </thead>
         <tbody>
-            {{#each model key="@index" as |item index|}}
-                <tr>
-                    <td>{{input type="checkbox" name="isChecked"}}</td>
-                    <td>{{index}}</td>
-                    <td>{{item.shortId}}</td>
-                    <td>{{item.json.individualName}}</td>
-                    <td>{{item.json.organizationName}}</td>
-                    <td>
-                        <button class="btn btn-xs btn-danger pull-right" {{action "deleteItem" item}}>
-                            <span class="fa fa-times"></span> Delete
-                        </button>
-                        <span class="pull-right">&nbsp;</span>
-                        <button class="btn btn-xs btn-warning pull-right" {{action "editItem" item}}>
+        {{#each model as |item index|}}
+            <tr>
+                <td>{{input type="checkbox" name="isChecked"}}</td>
+                <td>{{index}}</td>
+                <td>{{item.shortId}}</td>
+                <td>{{item.json.individualName}}</td>
+                <td>{{item.json.organizationName}}</td>
+                <td>
+                    <span class="pull-right">
+                        <button class="btn btn-xs btn-warning" {{action "editItem" item}}>
                             <span class="fa fa-pencil"></span> Edit
                         </button>
-                    </td>
-                </tr>
-            {{/each}}
+                        <button class="btn btn-xs btn-danger" {{action "deleteItem" item}}>
+                            <span class="fa fa-times"></span> Delete
+                        </button>
+                    </span>
+                </td>
+            </tr>
+        {{/each}}
         </tbody>
     </table>
 </div>
+
 {{outlet}}

--- a/app/pods/contacts/template.hbs
+++ b/app/pods/contacts/template.hbs
@@ -1,1 +1,35 @@
+<h3>Contacts Dashboard</h3>
+<div class="container-fluid">
+    <br>
+    <table class="table table-striped table-hover">
+        <thead>
+        <th></th>
+        <th>#</th>
+        <th>Contact ID</th>
+        <th>Individual Name</th>
+        <th>Organization Name</th>
+        <th></th>
+        </thead>
+        <tbody>
+            {{#each model key="@index" as |item index|}}
+                <tr>
+                    <td>{{input type="checkbox" name="isChecked"}}</td>
+                    <td>{{index}}</td>
+                    <td>{{item.json.contactId}}</td>
+                    <td>{{item.json.individualName}}</td>
+                    <td>{{item.json.organizationName}}</td>
+                    <td>
+                        <button class="btn btn-xs btn-danger pull-right" {{action "deleteItem" item}}>
+                            <span class="fa fa-times"></span> Delete
+                        </button>
+                        <span class="pull-right">&nbsp;</span>
+                        <button class="btn btn-xs btn-warning pull-right" {{action "editItem" item}}>
+                            <span class="fa fa-pencil"></span> Edit
+                        </button>
+                    </td>
+                </tr>
+            {{/each}}
+        </tbody>
+    </table>
+</div>
 {{outlet}}

--- a/app/pods/dictionaries/route.js
+++ b/app/pods/dictionaries/route.js
@@ -1,4 +1,27 @@
 import Ember from 'ember';
 
 export default Ember.Route.extend({
+  model() {
+    return this.store.findAll('dictionary');
+  },
+
+  actions: {
+    deleteItem: function(item) {
+      if (window.confirm(
+              "Do you really want to delete this dictionary?\n\n" +
+              "Be sure this dictionary is not referenced by an metadata records " +
+              "or it's deletion may cause those records to not validate.")) {
+        item.destroyRecord().then(function() {
+          console.log('+-- deleted dictionary ID:', item.id);
+        }, function() {
+          console.log('+--- delete dictionary failed');
+        });
+      }
+    },
+
+    editItem: function(item) {
+      this.transitionTo('dictionary.show.edit', item);
+    }
+  }
+
 });

--- a/app/pods/dictionaries/route.js
+++ b/app/pods/dictionaries/route.js
@@ -7,21 +7,27 @@ export default Ember.Route.extend({
 
   actions: {
     deleteItem: function(item) {
-      if (window.confirm(
-              "Do you really want to delete this dictionary?\n\n" +
-              "Be sure this dictionary is not referenced by an metadata records " +
-              "or it's deletion may cause those records to not validate.")) {
-        item.destroyRecord().then(function() {
-          console.log('+-- deleted dictionary ID:', item.id);
-        }, function() {
-          console.log('+--- delete dictionary failed');
-        });
-      }
+      let message =
+          "Do you really want to delete this dictionary?\n\n" +
+          "Be sure this dictionary is not referenced by an metadata records " +
+          "or it's deletion may cause those records to not validate.";
+      this._deleteItem(item, message);
     },
 
     editItem: function(item) {
       this.transitionTo('dictionary.show.edit', item);
     }
+  },
+  
+  // action methods
+  _deleteItem(item, message) {
+    if (window.confirm(message)) {
+      item.destroyRecord().then(function() {
+        console.log('+-- deleted dictionary ID:', item.id);
+      }, function() {
+        console.log('+-- delete dictionary failed');
+      });
+    }
   }
-
+  
 });

--- a/app/pods/dictionaries/route.js
+++ b/app/pods/dictionaries/route.js
@@ -22,11 +22,7 @@ export default Ember.Route.extend({
   // action methods
   _deleteItem(item, message) {
     if (window.confirm(message)) {
-      item.destroyRecord().then(function() {
-        console.log('+-- deleted dictionary ID:', item.id);
-      }, function() {
-        console.log('+-- delete dictionary failed');
-      });
+      item.destroyRecord();
     }
   }
   

--- a/app/pods/dictionaries/template.hbs
+++ b/app/pods/dictionaries/template.hbs
@@ -1,2 +1,33 @@
-List Dictionaries
+<h3>Dictionary Dashboard</h3>
+<div class="container-fluid">
+    <br>
+    <table class="table table-striped table-hover">
+        <thead>
+        <th></th>
+        <th>#</th>
+        <th>Dictionary Name</th>
+        <th>Data Resource Type</th>
+        <th></th>
+        </thead>
+        <tbody>
+        {{#each model key="@index" as |item index|}}
+            <tr>
+                <td>{{input type="checkbox" name="isChecked"}}</td>
+                <td>{{index}}</td>
+                <td>{{item.json.dictionaryInfo.citation.title}}</td>
+                <td>{{item.json.dictionaryInfo.resourceType}}</td>
+                <td>
+                    <button class="btn btn-xs btn-danger pull-right" {{action "deleteItem" item}}>
+                        <span class="fa fa-times"></span> Delete
+                    </button>
+                    <span class="pull-right">&nbsp;</span>
+                    <button class="btn btn-xs btn-warning pull-right" {{action "editItem" item}}>
+                        <span class="fa fa-pencil"></span> Edit
+                    </button>
+                </td>
+            </tr>
+        {{/each}}
+        </tbody>
+    </table>
+</div>
 {{outlet}}

--- a/app/pods/dictionaries/template.hbs
+++ b/app/pods/dictionaries/template.hbs
@@ -1,6 +1,6 @@
 <h3>Dictionary Dashboard</h3>
+
 <div class="container-fluid">
-    <br>
     <table class="table table-striped table-hover">
         <thead>
         <th></th>
@@ -10,24 +10,26 @@
         <th></th>
         </thead>
         <tbody>
-        {{#each model key="@index" as |item index|}}
+        {{#each model as |item index|}}
             <tr>
                 <td>{{input type="checkbox" name="isChecked"}}</td>
                 <td>{{index}}</td>
                 <td>{{item.json.dictionaryInfo.citation.title}}</td>
                 <td>{{item.json.dictionaryInfo.resourceType}}</td>
                 <td>
-                    <button class="btn btn-xs btn-danger pull-right" {{action "deleteItem" item}}>
-                        <span class="fa fa-times"></span> Delete
-                    </button>
-                    <span class="pull-right">&nbsp;</span>
-                    <button class="btn btn-xs btn-warning pull-right" {{action "editItem" item}}>
-                        <span class="fa fa-pencil"></span> Edit
-                    </button>
+                    <span class="pull-right">
+                        <button class="btn btn-xs btn-warning" {{action "editItem" item}}>
+                            <span class="fa fa-pencil"></span> Edit
+                        </button>
+                        <button class="btn btn-xs btn-danger" {{action "deleteItem" item}}>
+                            <span class="fa fa-times"></span> Delete
+                        </button>
+                    </span>
                 </td>
             </tr>
         {{/each}}
         </tbody>
     </table>
 </div>
+
 {{outlet}}

--- a/app/pods/dictionary/new/route.js
+++ b/app/pods/dictionary/new/route.js
@@ -1,4 +1,58 @@
 import Ember from 'ember';
 
 export default Ember.Route.extend({
+  model: function() {
+    return this.store.createRecord('dictionary');
+  },
+
+  deactivate: function() {
+    // We grab the model loaded in this route
+    let model = this.modelFor('dictionary/new');
+
+    // If we are leaving the Route we verify if the model is in
+    // 'isNew' state, which means it wasn't saved to the backend.
+    if (model.get('isNew')) {
+      // We call DS#destroyRecord() which removes it from the store
+      model.destroyRecord();
+    }
+  },
+
+  //some test actions
+  setupController: function(controller, model) {
+    // Call _super for default behavior
+    this._super(controller, model);
+
+    // setup tests for required attributes
+    controller.noName = Ember.computed(
+      'model.json.dictionaryInfo.citation.title', function() {
+        return model.get('title') ? false : true;
+      });
+    controller.noType = Ember.computed(
+      'model.json.dictionaryInfo.resourceType', function() {
+        return model.get('json.dictionaryInfo.resourceType') ? false : true;
+      });
+  },
+
+  actions: {
+    saveDictionary() {
+      let haveName = !this.controller.get('noName');
+      let haveType = !this.controller.get('noType');
+      if (haveName && haveType) {
+        this.modelFor('dictionary.new')
+          .save()
+          .then((model) => {
+            this.transitionTo('dictionary.show.edit', model);
+          });
+      }
+
+      return false;
+    },
+
+    cancelDictionary() {
+      this.transitionTo('dictionaries');
+
+      return false;
+    }
+  }
+
 });

--- a/app/pods/dictionary/new/route.js
+++ b/app/pods/dictionary/new/route.js
@@ -25,27 +25,25 @@ export default Ember.Route.extend({
     // setup tests for required attributes
     controller.noName = Ember.computed(
       'model.json.dictionaryInfo.citation.title', function() {
-        return model.get('title') ? false : true;
+        return model.get('json.dictionaryInfo.citation.title') ? false : true;
       });
     controller.noType = Ember.computed(
       'model.json.dictionaryInfo.resourceType', function() {
         return model.get('json.dictionaryInfo.resourceType') ? false : true;
       });
+    controller.allowSave = Ember.computed('noType', 'noName', function () {
+      return (this.get('noName') || this.get('noType'));
+    });
+  
   },
 
   actions: {
     saveDictionary() {
-      let haveName = !this.controller.get('noName');
-      let haveType = !this.controller.get('noType');
-      if (haveName && haveType) {
-        this.modelFor('dictionary.new')
-          .save()
-          .then((model) => {
-            this.transitionTo('dictionary.show.edit', model);
-          });
-      }
-
-      return false;
+      this.modelFor('dictionary.new')
+        .save()
+        .then((model) => {
+          this.transitionTo('dictionary.show.edit', model);
+        });
     },
 
     cancelDictionary() {

--- a/app/pods/dictionary/new/template.hbs
+++ b/app/pods/dictionary/new/template.hbs
@@ -5,51 +5,54 @@
             choose a data resource type.</p>
     </div>
 </div>
-<div class="row">
+
+<div class="container">
     <div class="col-md-6 col-md-offset-3">
-        <form class="form-horizontal">
-            <div class="form-group">
-                <div class="col-sm-12">
-                    {{#if noName}}
-                        <div class="alert alert-danger md-form-alert" role="alert">
-                            You must provide a name for this dictionary.
-                        </div>
-                    {{/if}}
-                    {{#if noType}}
-                        <div class="alert alert-danger md-form-alert" role="alert">
-                            You must choose a type for this data resource.
-                        </div>
-                    {{/if}}
+        <div class="col-sm-12">
+            {{#if noName}}
+                <div class="alert alert-danger md-form-alert" role="alert">
+                    You must provide a name for this dictionary.
                 </div>
-            </div>
-            <div class="form-group">
-                <label class="col-sm-3 control-label">Dictionary Name</label>
-                <div class="col-sm-9">
-                    {{input/md-input
-                    value=model.json.dictionaryInfo.citation.title
-                    placeholder="Enter an name for this dictionary"}}
+            {{/if}}
+            {{#if noType}}
+                <div class="alert alert-danger md-form-alert" role="alert">
+                    You must choose a type for this data resource.
                 </div>
+            {{/if}}
+        </div>
+    </div>
+</div>
+
+<div class="container">
+    <div class="form-horizontal col-md-6 col-md-offset-3">
+        <div class="form-group">
+            <label class="col-sm-3 control-label">Dictionary Name</label>
+            <div class="col-sm-9">
+                {{input/md-input
+                value=model.json.dictionaryInfo.citation.title
+                placeholder="Enter an name for this dictionary"}}
             </div>
-            <div class="form-group">
-                <label class="col-sm-3 control-label">Data Resource Type</label>
-                <div class="col-sm-9 md-form-select">
-                    {{input/md-codelist
-                    value=model.json.dictionaryInfo.resourceType
-                    create=true
-                    tooltip=true
-                    icon=true
-                    mdCodeName="scope"
-                    placeholder="Choose a type for this data resource"}}
-                </div>
+        </div>
+        <div class="form-group">
+            <label class="col-sm-3 control-label">Data Resource Type</label>
+            <div class="col-sm-9 md-form-select">
+                {{input/md-codelist
+                value=model.json.dictionaryInfo.resourceType
+                create=true
+                tooltip=true
+                icon=true
+                mdCodeName="scope"
+                placeholder="Choose a type for this data resource"}}
             </div>
-            <div class="form-group">
-                <div class="col-sm-offset-4 col-sm-8">
-                    <button {{action "cancelDictionary"}} class="btn btn-warning pull-right">Cancel</button>
-                    <span class="pull-right">&nbsp;</span>
-                    <button {{action "saveDictionary"}} class="btn btn-success pull-right md-form-save"
-                                                        disabled={{allowSave}}>Save</button>
-                </div>
+        </div>
+        <div class="form-group">
+            <div class="col-sm-offset-4 col-sm-8">
+                 <span class="pull-right">
+                      <button {{action "saveDictionary"}} class="btn btn-success md-form-save"
+                                                          disabled={{allowSave}}>Save</button>
+                      <button {{action "cancelDictionary"}} class="btn btn-warning ">Cancel</button>
+                 </span>
             </div>
-        </form>
+        </div>
     </div>
 </div>

--- a/app/pods/dictionary/new/template.hbs
+++ b/app/pods/dictionary/new/template.hbs
@@ -1,2 +1,54 @@
-New Dictionary
-{{outlet}}
+<div class="row text-center">
+    <div class="col-md-8 col-md-offset-2">
+        <h3>Create New Data Dictionary</h3>
+        <p class="text-center">To create a <em> new</em> data dictionary, enter a dictionary name and
+            choose a data resource type.</p>
+    </div>
+</div>
+<div class="row">
+    <div class="col-md-6 col-md-offset-3">
+        <form class="form-horizontal">
+            <div class="form-group">
+                <div class="col-sm-12">
+                    {{#if noName}}
+                        <div class="alert alert-danger" role="alert">
+                            You must provide a name for this dictionary.
+                        </div>
+                    {{/if}}
+                    {{#if noType}}
+                        <div class="alert alert-danger" role="alert">
+                            You must choose a type for this data resource.
+                        </div>
+                    {{/if}}
+                </div>
+            </div>
+            <div class="form-group">
+                <label class="col-sm-3 control-label">Dictionary Name</label>
+                <div class="col-sm-9">
+                    {{input/md-input
+                    value=model.json.dictionaryInfo.citation.title
+                    placeholder="Enter an name for this dictionary"}}
+                </div>
+            </div>
+            <div class="form-group">
+                <label class="col-sm-3 control-label">Data Resource Type</label>
+                <div class="col-sm-9">
+                    {{input/md-codelist
+                    value=model.json.dictionaryInfo.resourceType
+                    create=true
+                    tooltip=true
+                    icon=true
+                    mdCodeName="scope"
+                    placeholder="Choose a type for this data resource"}}
+                </div>
+            </div>
+            <div class="form-group">
+                <div class="col-sm-offset-4 col-sm-8">
+                    <button {{action "cancelDictionary"}} class="btn btn-warning pull-right">Cancel</button>
+                    <span class="pull-right">&nbsp;</span>
+                    <button {{action "saveDictionary"}} class="btn btn-success pull-right">Save</button>
+                </div>
+            </div>
+        </form>
+    </div>
+</div>

--- a/app/pods/dictionary/new/template.hbs
+++ b/app/pods/dictionary/new/template.hbs
@@ -11,12 +11,12 @@
             <div class="form-group">
                 <div class="col-sm-12">
                     {{#if noName}}
-                        <div class="alert alert-danger" role="alert">
+                        <div class="alert alert-danger md-form-alert" role="alert">
                             You must provide a name for this dictionary.
                         </div>
                     {{/if}}
                     {{#if noType}}
-                        <div class="alert alert-danger" role="alert">
+                        <div class="alert alert-danger md-form-alert" role="alert">
                             You must choose a type for this data resource.
                         </div>
                     {{/if}}
@@ -32,7 +32,7 @@
             </div>
             <div class="form-group">
                 <label class="col-sm-3 control-label">Data Resource Type</label>
-                <div class="col-sm-9">
+                <div class="col-sm-9 md-form-select">
                     {{input/md-codelist
                     value=model.json.dictionaryInfo.resourceType
                     create=true
@@ -46,7 +46,8 @@
                 <div class="col-sm-offset-4 col-sm-8">
                     <button {{action "cancelDictionary"}} class="btn btn-warning pull-right">Cancel</button>
                     <span class="pull-right">&nbsp;</span>
-                    <button {{action "saveDictionary"}} class="btn btn-success pull-right">Save</button>
+                    <button {{action "saveDictionary"}} class="btn btn-success pull-right md-form-save"
+                                                        disabled={{allowSave}}>Save</button>
                 </div>
             </div>
         </form>

--- a/app/pods/record/new/route.js
+++ b/app/pods/record/new/route.js
@@ -31,21 +31,18 @@ export default Ember.Route.extend({
       'model.json.metadata.resourceInfo.resourceType', function() {
         return model.get('json.metadata.resourceInfo.resourceType') ? false : true;
       });
+    controller.allowSave = Ember.computed('noType', 'noTitle', function () {
+      return (this.get('noTitle') || this.get('noType'));
+    });
   },
 
   actions: {
     saveRecord() {
-      let haveTitle = !this.controller.get('noTitle');
-      let haveType = !this.controller.get('noType');
-      if (haveTitle && haveType) {
-        this.modelFor('record.new')
-          .save()
-          .then((model) => {
-            this.transitionTo('record.show.edit', model);
-          });
-      }
-
-      return false;
+      this.modelFor('record.new')
+        .save()
+        .then((model) => {
+          this.transitionTo('record.show.edit', model);
+        });
     },
 
     cancelRecord() {

--- a/app/pods/record/new/route.js
+++ b/app/pods/record/new/route.js
@@ -1,10 +1,11 @@
 import Ember from 'ember';
 
 export default Ember.Route.extend({
-  model: function () {
+  model: function() {
     return this.store.createRecord('record');
   },
-  deactivate: function () {
+
+  deactivate: function() {
     // We grab the model loaded in this route
     let model = this.modelFor('record/new');
 
@@ -15,35 +16,43 @@ export default Ember.Route.extend({
       model.destroyRecord();
     }
   },
+
   //some test actions
-  setupController: function (controller, model) {
-    controller.actions = {
-      save() {
-        this.send('saveMe');
-      }
-    };
+  setupController: function(controller, model) {
     // Call _super for default behavior
     this._super(controller, model);
-    controller.notValid = Ember.computed(
-      'model.json.metadata.resourceInfo.citation.title',
-      function () {
+
+    // setup tests for required attributes
+    controller.noTitle = Ember.computed(
+      'model.json.metadata.resourceInfo.citation.title', function() {
         return model.get('title') ? false : true;
       });
+    controller.noType = Ember.computed(
+      'model.json.metadata.resourceInfo.resourceType', function() {
+        return model.get('json.metadata.resourceInfo.resourceType') ? false : true;
+      });
   },
+
   actions: {
-    saveMe() {
+    saveRecord() {
+      let haveTitle = !this.controller.get('noTitle');
+      let haveType = !this.controller.get('noType');
+      if (haveTitle && haveType) {
         this.modelFor('record.new')
           .save()
           .then((model) => {
             this.transitionTo('record.show.edit', model);
           });
-
-        return false;
-      },
-      cancel() {
-        this.transitionTo('records');
-
-        return false;
       }
+
+      return false;
+    },
+
+    cancelRecord() {
+      this.transitionTo('records');
+
+      return false;
+    }
   }
+
 });

--- a/app/pods/record/new/template.hbs
+++ b/app/pods/record/new/template.hbs
@@ -10,12 +10,12 @@
             <div class="form-group">
                 <div class="col-sm-12">
                     {{#if noTitle}}
-                        <div class="alert alert-danger" role="alert">
+                        <div class="alert alert-danger md-form-alert" role="alert">
                             You must provide a Record Title.
                         </div>
                     {{/if}}
                     {{#if noType}}
-                        <div class="alert alert-danger" role="alert">
+                        <div class="alert alert-danger md-form-alert" role="alert">
                             You must provide a Record Type.
                         </div>
                     {{/if}}
@@ -31,7 +31,7 @@
             </div>
             <div class="form-group">
                 <label class="col-sm-4 control-label">Choose Type</label>
-                <div class="col-sm-8">
+                <div class="col-sm-8 md-form-select">
                     {{input/md-codelist
                     value=model.json.metadata.resourceInfo.resourceType
                     create=true tooltip=true icon=true mdCodeName="scope"
@@ -42,7 +42,8 @@
                 <div class="col-sm-offset-4 col-sm-8">
                     <button {{action "cancelRecord"}} class="btn btn-warning pull-right">Cancel</button>
                     <span class="pull-right">&nbsp;</span>
-                    <button {{action "saveRecord"}} class="btn btn-success pull-right">Save</button>
+                    <button {{action "saveRecord"}} class="btn btn-success pull-right md-form-save"
+                                                    disabled={{allowSave}}>Save</button>
                 </div>
             </div>
         </form>

--- a/app/pods/record/new/template.hbs
+++ b/app/pods/record/new/template.hbs
@@ -1,50 +1,51 @@
 <div class="row text-center">
-  <div class="col-md-8 col-md-offset-2">
-    <h3>Create New Record</h3>
-    <p class="text-center">To create a <em> new</em> metadata record, enter a title and select a record type.</p>
-  </div>
+    <div class="col-md-8 col-md-offset-2">
+        <h3>Create New Record</h3>
+        <p class="text-center">To create a <em> new</em> metadata record, enter a title and select a record type.</p>
+    </div>
 </div>
 <div class="row">
-  <div class="col-md-6 col-md-offset-3">
-    <form class="form-horizontal">
-      <div class="form-group">
-        <div class="col-sm-12">
-          {{#if notValid}}
-            <div class="alert alert-danger" role="alert">
-              You must provide a Record Title.
+    <div class="col-md-6 col-md-offset-3">
+        <form class="form-horizontal">
+            <div class="form-group">
+                <div class="col-sm-12">
+                    {{#if noTitle}}
+                        <div class="alert alert-danger md-form-alert" role="alert">
+                            You must provide a Record Title.
+                        </div>
+                    {{/if}}
+                    {{#if noType}}
+                        <div class="alert alert-danger md-form-alert" role="alert">
+                            You must provide a Record Type.
+                        </div>
+                    {{/if}}
+                </div>
             </div>
-          {{/if}}
-        </div>
-      </div>
-      <div class="form-group">
-        <label for="input-title" class="col-sm-4 control-label">Record Title</label>
-        <div class="col-sm-8">
-          {{input value=model.json.metadata.resourceInfo.citation.title placeholder='Enter a title' class='form-control' id='input-title'}}
-        </div>
-      </div>
-      <div class="form-group">
-        <label class="col-sm-4 control-label">Choose Type</label>
-        <div class="col-sm-8 text-center">
-          {{input/md-codelist
-            change=(action "save")
-            disabled=notValid
-            create=true
-            tooltip=true
-            icon=true
-            allowClear=false
-            value=model.json.metadata.resourceInfo.resourceType
-            mdCodeName="scope"
-            placeholder="Pick a record type"
-            label=false}}
-        </div>
-      </div>
-      <div class="form-group">
-        <div class="col-sm-offset-4 col-sm-8">
-          <button {{action "cancel"}} class="btn btn-warning btn-block">
-            Cancel
-          </button>
-        </div>
-      </div>
-    </form>
-  </div>
+            <div class="form-group">
+                <label class="col-sm-4 control-label">Record Title</label>
+                <div class="col-sm-8">
+                    {{input/md-input
+                    value=model.json.metadata.resourceInfo.citation.title
+                    placeholder='Enter a title for the record'}}
+                </div>
+            </div>
+            <div class="form-group">
+                <label class="col-sm-4 control-label">Choose Type</label>
+                <div class="col-sm-8 md-form-select">
+                    {{input/md-codelist
+                    value=model.json.metadata.resourceInfo.resourceType
+                    create=true tooltip=true icon=true mdCodeName="scope"
+                    placeholder="Pick a record type"}}
+                </div>
+            </div>
+            <div class="form-group">
+                <div class="col-sm-offset-4 col-sm-8">
+                    <button {{action "cancelRecord"}} class="btn btn-warning pull-right">Cancel</button>
+                    <span class="pull-right">&nbsp;</span>
+                    <button {{action "saveRecord"}} class="btn btn-success pull-right md-form-save"
+                                                    disabled={{allowSave}}>Save</button>
+                </div>
+            </div>
+        </form>
+    </div>
 </div>

--- a/app/pods/record/new/template.hbs
+++ b/app/pods/record/new/template.hbs
@@ -1,51 +1,50 @@
 <div class="row text-center">
-    <div class="col-md-8 col-md-offset-2">
-        <h3>Create New Record</h3>
-        <p class="text-center">To create a <em> new</em> metadata record, enter a title and select a record type.</p>
-    </div>
+  <div class="col-md-8 col-md-offset-2">
+    <h3>Create New Record</h3>
+    <p class="text-center">To create a <em> new</em> metadata record, enter a title and select a record type.</p>
+  </div>
 </div>
 <div class="row">
-    <div class="col-md-6 col-md-offset-3">
-        <form class="form-horizontal">
-            <div class="form-group">
-                <div class="col-sm-12">
-                    {{#if noTitle}}
-                        <div class="alert alert-danger md-form-alert" role="alert">
-                            You must provide a Record Title.
-                        </div>
-                    {{/if}}
-                    {{#if noType}}
-                        <div class="alert alert-danger md-form-alert" role="alert">
-                            You must provide a Record Type.
-                        </div>
-                    {{/if}}
-                </div>
+  <div class="col-md-6 col-md-offset-3">
+    <form class="form-horizontal">
+      <div class="form-group">
+        <div class="col-sm-12">
+          {{#if notValid}}
+            <div class="alert alert-danger" role="alert">
+              You must provide a Record Title.
             </div>
-            <div class="form-group">
-                <label class="col-sm-4 control-label">Record Title</label>
-                <div class="col-sm-8">
-                    {{input/md-input
-                    value=model.json.metadata.resourceInfo.citation.title
-                    placeholder='Enter a title for the record'}}
-                </div>
-            </div>
-            <div class="form-group">
-                <label class="col-sm-4 control-label">Choose Type</label>
-                <div class="col-sm-8 md-form-select">
-                    {{input/md-codelist
-                    value=model.json.metadata.resourceInfo.resourceType
-                    create=true tooltip=true icon=true mdCodeName="scope"
-                    placeholder="Pick a record type"}}
-                </div>
-            </div>
-            <div class="form-group">
-                <div class="col-sm-offset-4 col-sm-8">
-                    <button {{action "cancelRecord"}} class="btn btn-warning pull-right">Cancel</button>
-                    <span class="pull-right">&nbsp;</span>
-                    <button {{action "saveRecord"}} class="btn btn-success pull-right md-form-save"
-                                                    disabled={{allowSave}}>Save</button>
-                </div>
-            </div>
-        </form>
-    </div>
+          {{/if}}
+        </div>
+      </div>
+      <div class="form-group">
+        <label for="input-title" class="col-sm-4 control-label">Record Title</label>
+        <div class="col-sm-8">
+          {{input value=model.json.metadata.resourceInfo.citation.title placeholder='Enter a title' class='form-control' id='input-title'}}
+        </div>
+      </div>
+      <div class="form-group">
+        <label class="col-sm-4 control-label">Choose Type</label>
+        <div class="col-sm-8 text-center">
+          {{input/md-codelist
+            change=(action "save")
+            disabled=notValid
+            create=true
+            tooltip=true
+            icon=true
+            allowClear=false
+            value=model.json.metadata.resourceInfo.resourceType
+            mdCodeName="scope"
+            placeholder="Pick a record type"
+            label=false}}
+        </div>
+      </div>
+      <div class="form-group">
+        <div class="col-sm-offset-4 col-sm-8">
+          <button {{action "cancel"}} class="btn btn-warning btn-block">
+            Cancel
+          </button>
+        </div>
+      </div>
+    </form>
+  </div>
 </div>

--- a/app/pods/record/new/template.hbs
+++ b/app/pods/record/new/template.hbs
@@ -1,50 +1,50 @@
 <div class="row text-center">
-  <div class="col-md-8 col-md-offset-2">
-    <h3>Create New Record</h3>
-    <p class="text-center">To create a <em> new</em> metadata record, enter a title and select a record type.</p>
-  </div>
+    <div class="col-md-8 col-md-offset-2">
+        <h3>Create New Record</h3>
+        <p class="text-center">To create a <em> new</em> metadata record, enter a title and select a record type.</p>
+    </div>
 </div>
 <div class="row">
-  <div class="col-md-6 col-md-offset-3">
-    <form class="form-horizontal">
-      <div class="form-group">
-        <div class="col-sm-12">
-          {{#if notValid}}
-            <div class="alert alert-danger" role="alert">
-              You must provide a Record Title.
+    <div class="col-md-6 col-md-offset-3">
+        <form class="form-horizontal">
+            <div class="form-group">
+                <div class="col-sm-12">
+                    {{#if noTitle}}
+                        <div class="alert alert-danger" role="alert">
+                            You must provide a Record Title.
+                        </div>
+                    {{/if}}
+                    {{#if noType}}
+                        <div class="alert alert-danger" role="alert">
+                            You must provide a Record Type.
+                        </div>
+                    {{/if}}
+                </div>
             </div>
-          {{/if}}
-        </div>
-      </div>
-      <div class="form-group">
-        <label for="input-title" class="col-sm-4 control-label">Record Title</label>
-        <div class="col-sm-8">
-          {{input value=model.json.metadata.resourceInfo.citation.title placeholder='Enter a title' class='form-control' id='input-title'}}
-        </div>
-      </div>
-      <div class="form-group">
-        <label class="col-sm-4 control-label">Choose Type</label>
-        <div class="col-sm-8 text-center">
-          {{input/md-codelist
-            change=(action "save")
-            disabled=notValid
-            create=true
-            tooltip=true
-            icon=true
-            allowClear=false
-            value=model.json.metadata.resourceInfo.resourceType
-            mdCodeName="scope"
-            placeholder="Pick a record type"
-            label=false}}
-        </div>
-      </div>
-      <div class="form-group">
-        <div class="col-sm-offset-4 col-sm-8">
-          <button {{action "cancel"}} class="btn btn-warning btn-block">
-            Cancel
-          </button>
-        </div>
-      </div>
-    </form>
-  </div>
+            <div class="form-group">
+                <label class="col-sm-4 control-label">Record Title</label>
+                <div class="col-sm-8">
+                    {{input/md-input
+                    value=model.json.metadata.resourceInfo.citation.title
+                    placeholder='Enter a title for the record'}}
+                </div>
+            </div>
+            <div class="form-group">
+                <label class="col-sm-4 control-label">Choose Type</label>
+                <div class="col-sm-8">
+                    {{input/md-codelist
+                    value=model.json.metadata.resourceInfo.resourceType
+                    create=true tooltip=true icon=true mdCodeName="scope"
+                    placeholder="Pick a record type"}}
+                </div>
+            </div>
+            <div class="form-group">
+                <div class="col-sm-offset-4 col-sm-8">
+                    <button {{action "cancelRecord"}} class="btn btn-warning pull-right">Cancel</button>
+                    <span class="pull-right">&nbsp;</span>
+                    <button {{action "saveRecord"}} class="btn btn-success pull-right">Save</button>
+                </div>
+            </div>
+        </form>
+    </div>
 </div>

--- a/app/pods/record/new/template.hbs
+++ b/app/pods/record/new/template.hbs
@@ -4,48 +4,51 @@
         <p class="text-center">To create a <em> new</em> metadata record, enter a title and select a record type.</p>
     </div>
 </div>
-<div class="row">
+
+<div class="container">
     <div class="col-md-6 col-md-offset-3">
-        <form class="form-horizontal">
-            <div class="form-group">
-                <div class="col-sm-12">
-                    {{#if noTitle}}
-                        <div class="alert alert-danger md-form-alert" role="alert">
-                            You must provide a Record Title.
-                        </div>
-                    {{/if}}
-                    {{#if noType}}
-                        <div class="alert alert-danger md-form-alert" role="alert">
-                            You must provide a Record Type.
-                        </div>
-                    {{/if}}
+        <div class="col-sm-12">
+            {{#if noTitle}}
+                <div class="alert alert-danger md-form-alert" role="alert">
+                    You must provide a Record Title.
                 </div>
-            </div>
-            <div class="form-group">
-                <label class="col-sm-4 control-label">Record Title</label>
-                <div class="col-sm-8">
-                    {{input/md-input
-                    value=model.json.metadata.resourceInfo.citation.title
-                    placeholder='Enter a title for the record'}}
+            {{/if}}
+            {{#if noType}}
+                <div class="alert alert-danger md-form-alert" role="alert">
+                    You must provide a Record Type.
                 </div>
+            {{/if}}
+        </div>
+    </div>
+</div>
+
+<div class="container">
+    <div class="form-horizontal col-md-6 col-md-offset-3">
+        <div class="form-group">
+            <label class="col-sm-4 control-label">Record Title</label>
+            <div class="col-sm-8">
+                {{input/md-input
+                value=model.json.metadata.resourceInfo.citation.title
+                placeholder='Enter a title for the record'}}
             </div>
-            <div class="form-group">
-                <label class="col-sm-4 control-label">Choose Type</label>
-                <div class="col-sm-8 md-form-select">
-                    {{input/md-codelist
-                    value=model.json.metadata.resourceInfo.resourceType
-                    create=true tooltip=true icon=true mdCodeName="scope"
-                    placeholder="Pick a record type"}}
-                </div>
+        </div>
+        <div class="form-group">
+            <label class="col-sm-4 control-label">Choose Type</label>
+            <div class="col-sm-8 md-form-select">
+                {{input/md-codelist
+                value=model.json.metadata.resourceInfo.resourceType
+                create=true tooltip=true icon=true mdCodeName="scope"
+                placeholder="Pick a record type"}}
             </div>
-            <div class="form-group">
-                <div class="col-sm-offset-4 col-sm-8">
-                    <button {{action "cancelRecord"}} class="btn btn-warning pull-right">Cancel</button>
-                    <span class="pull-right">&nbsp;</span>
-                    <button {{action "saveRecord"}} class="btn btn-success pull-right md-form-save"
-                                                    disabled={{allowSave}}>Save</button>
-                </div>
+        </div>
+        <div class="form-group">
+            <div class="col-sm-offset-4 col-sm-8">
+                 <span class="pull-right">
+                      <button {{action "saveRecord"}} class="btn btn-success md-form-save"
+                                                      disabled={{allowSave}}>Save</button>
+                      <button {{action "cancelRecord"}} class="btn btn-warning ">Cancel</button>
+                 </span>
             </div>
-        </form>
+        </div>
     </div>
 </div>

--- a/app/pods/records/route.js
+++ b/app/pods/records/route.js
@@ -17,18 +17,24 @@ export default Ember.Route.extend({
 
   actions: {
     deleteItem: function(item) {
-      if (window.confirm(
-              "Do you really want to delete this record?")) {
-        item.destroyRecord().then(function() {
-          console.log('+-- deleted record ID:', item.id);
-        }, function() {
-          console.log('+--- delete record failed');
-        });
-      }
+      let message =
+        "Do you really want to delete this record?";
+      this._deleteItem(item, message);
     },
 
     editItem: function(item) {
       this.transitionTo('record.show.edit', item);
+    }
+  },
+
+  // action methods
+  _deleteItem(item, message) {
+    if (window.confirm(message)) {
+      item.destroyRecord().then(function() {
+        console.log('+-- deleted record ID:', item.id);
+      }, function() {
+        console.log('+-- delete record failed');
+      });
     }
   }
 

--- a/app/pods/records/route.js
+++ b/app/pods/records/route.js
@@ -1,9 +1,9 @@
 import Ember from 'ember';
 
 export default Ember.Route.extend({
-  /*beforeModel() {
-      this.transitionTo('records.list');
-    },*/
+  model() {
+    return this.store.findAll('record');
+  },
 
   renderTemplate() {
     this.render('records.nav', {
@@ -13,5 +13,23 @@ export default Ember.Route.extend({
     this.render('records', {
       into: 'application'
     });
+  },
+
+  actions: {
+    deleteItem: function(item) {
+      if (window.confirm(
+              "Do you really want to delete this record?")) {
+        item.destroyRecord().then(function() {
+          console.log('+-- deleted record ID:', item.id);
+        }, function() {
+          console.log('+--- delete record failed');
+        });
+      }
+    },
+
+    editItem: function(item) {
+      this.transitionTo('record.show.edit', item);
+    }
   }
+
 });

--- a/app/pods/records/route.js
+++ b/app/pods/records/route.js
@@ -30,11 +30,7 @@ export default Ember.Route.extend({
   // action methods
   _deleteItem(item, message) {
     if (window.confirm(message)) {
-      item.destroyRecord().then(function() {
-        console.log('+-- deleted record ID:', item.id);
-      }, function() {
-        console.log('+-- delete record failed');
-      });
+      item.destroyRecord();
     }
   }
 

--- a/app/pods/records/template.hbs
+++ b/app/pods/records/template.hbs
@@ -1,70 +1,33 @@
-<h3>List of records.</h3>
-
-<div class="bs-example" data-example-id="contextual-table">
-  <table class="table">
-    <thead>
-      <tr>
+<h3>Metadata Record Dashboard</h3>
+<div class="container-fluid">
+    <br>
+    <table class="table table-striped table-hover">
+        <thead>
+        <th></th>
         <th>#</th>
-        <th>Column heading</th>
-        <th>Column heading</th>
-        <th>Column heading</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr class="active">
-        <th scope="row">1</th>
-        <td>Column content</td>
-        <td>Column content</td>
-        <td>Column content</td>
-      </tr>
-      <tr>
-        <th scope="row">2</th>
-        <td>Column content</td>
-        <td>Column content</td>
-        <td>Column content</td>
-      </tr>
-      <tr class="success">
-        <th scope="row">3</th>
-        <td>Column content</td>
-        <td>Column content</td>
-        <td>Column content</td>
-      </tr>
-      <tr>
-        <th scope="row">4</th>
-        <td>Column content</td>
-        <td>Column content</td>
-        <td>Column content</td>
-      </tr>
-      <tr class="info">
-        <th scope="row">5</th>
-        <td>Column content</td>
-        <td>Column content</td>
-        <td>Column content</td>
-      </tr>
-      <tr>
-        <th scope="row">6</th>
-        <td>Column content</td>
-        <td>Column content</td>
-        <td>Column content</td>
-      </tr>
-      <tr class="warning">
-        <th scope="row">7</th>
-        <td>Column content</td>
-        <td>Column content</td>
-        <td>Column content</td>
-      </tr>
-      <tr>
-        <th scope="row">8</th>
-        <td>Column content</td>
-        <td>Column content</td>
-        <td>Column content</td>
-      </tr>
-      <tr class="danger">
-        <th scope="row">9</th>
-        <td>Column content</td>
-        <td>Column content</td>
-        <td>Column content</td>
-      </tr>
-    </tbody>
-  </table>
+        <th>Record Name</th>
+        <th>Resource Type</th>
+        <th></th>
+        </thead>
+        <tbody>
+        {{#each model key="@index" as |item index|}}
+            <tr>
+                <td>{{input type="checkbox" name="isChecked"}}</td>
+                <td>{{index}}</td>
+                <td>{{item.json.metadata.resourceInfo.citation.title}}</td>
+                <td>{{item.json.metadata.resourceInfo.resourceType}}</td>
+                <td>
+                    <button class="btn btn-xs btn-danger pull-right" {{action "deleteItem" item}}>
+                        <span class="fa fa-times"></span> Delete
+                    </button>
+                    <span class="pull-right">&nbsp;</span>
+                    <button class="btn btn-xs btn-warning pull-right" {{action "editItem" item}}>
+                        <span class="fa fa-pencil"></span> Edit
+                    </button>
+                </td>
+            </tr>
+        {{/each}}
+        </tbody>
+    </table>
 </div>
+{{outlet}}

--- a/app/pods/records/template.hbs
+++ b/app/pods/records/template.hbs
@@ -1,6 +1,6 @@
 <h3>Metadata Record Dashboard</h3>
+
 <div class="container-fluid">
-    <br>
     <table class="table table-striped table-hover">
         <thead>
         <th></th>
@@ -10,24 +10,26 @@
         <th></th>
         </thead>
         <tbody>
-        {{#each model key="@index" as |item index|}}
+        {{#each model as |item index|}}
             <tr>
                 <td>{{input type="checkbox" name="isChecked"}}</td>
                 <td>{{index}}</td>
                 <td>{{item.json.metadata.resourceInfo.citation.title}}</td>
                 <td>{{item.json.metadata.resourceInfo.resourceType}}</td>
                 <td>
-                    <button class="btn btn-xs btn-danger pull-right" {{action "deleteItem" item}}>
-                        <span class="fa fa-times"></span> Delete
-                    </button>
-                    <span class="pull-right">&nbsp;</span>
-                    <button class="btn btn-xs btn-warning pull-right" {{action "editItem" item}}>
-                        <span class="fa fa-pencil"></span> Edit
-                    </button>
+                    <span class="pull-right">
+                        <button class="btn btn-xs btn-warning" {{action "editItem" item}}>
+                            <span class="fa fa-pencil"></span> Edit
+                        </button>
+                        <button class="btn btn-xs btn-danger" {{action "deleteItem" item}}>
+                            <span class="fa fa-times"></span> Delete
+                        </button>
+                    </span>
                 </td>
             </tr>
         {{/each}}
         </tbody>
     </table>
 </div>
+
 {{outlet}}

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,6 @@
 {
   "name": "mdeditor",
   "dependencies": {
-    "dom-ruler": "^0.1.13",
     "ember": "~2.3.0",
     "ember-cli-shims": "0.0.6",
     "ember-cli-test-loader": "0.2.1",
@@ -10,14 +9,15 @@
     "ember-qunit": "0.4.16",
     "ember-qunit-notifications": "0.1.0",
     "ember-resolver": "~0.1.20",
-    "eonasdan-bootstrap-datetimepicker": "^4.17.37",
     "jquery": "^2.1.0",
     "loader.js": "ember-cli/loader.js#3.4.0",
     "qunit": "~1.20.0",
     "font-awesome": "~4.5.0",
     "bootstrap-sass": "~3.3.6",
     "select2": "^4.0.1",
-    "select2-bootstrap-theme": "^0.1.0-beta.4"
+    "select2-bootstrap-theme": "^0.1.0-beta.4",
+    "eonasdan-bootstrap-datetimepicker": "^4.17.37",
+    "dom-ruler": "0.1.13"
   },
   "resolutions": {
     "ember": "~2.3.0"

--- a/bower.json
+++ b/bower.json
@@ -9,14 +9,14 @@
     "ember-qunit": "0.4.16",
     "ember-qunit-notifications": "0.1.0",
     "ember-resolver": "~0.1.20",
+    "eonasdan-bootstrap-datetimepicker": "^4.17.37",
     "jquery": "^2.1.0",
     "loader.js": "ember-cli/loader.js#3.4.0",
     "qunit": "~1.20.0",
     "font-awesome": "~4.5.0",
     "bootstrap-sass": "~3.3.6",
     "select2": "^4.0.1",
-    "select2-bootstrap-theme": "^0.1.0-beta.4",
-    "dom-ruler": "0.1.13"
+    "select2-bootstrap-theme": "^0.1.0-beta.4"
   },
   "resolutions": {
     "ember": "~2.3.0"

--- a/bower.json
+++ b/bower.json
@@ -16,7 +16,6 @@
     "bootstrap-sass": "~3.3.6",
     "select2": "^4.0.1",
     "select2-bootstrap-theme": "^0.1.0-beta.4",
-    "eonasdan-bootstrap-datetimepicker": "~4.14.30",
     "dom-ruler": "0.1.13"
   },
   "resolutions": {

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,7 @@
 {
   "name": "mdeditor",
   "dependencies": {
+    "dom-ruler": "^0.1.13",
     "ember": "~2.3.0",
     "ember-cli-shims": "0.0.6",
     "ember-cli-test-loader": "0.2.1",

--- a/bower.json
+++ b/bower.json
@@ -18,8 +18,5 @@
     "select2-bootstrap-theme": "^0.1.0-beta.4",
     "eonasdan-bootstrap-datetimepicker": "^4.17.37",
     "dom-ruler": "0.1.13"
-  },
-  "resolutions": {
-    "ember": "~2.3.0"
   }
 }

--- a/config/environment.js
+++ b/config/environment.js
@@ -2,6 +2,9 @@
 
 module.exports = function(environment) {
   var ENV = {
+    contentSecurityPolicy: {
+      'style-src': "'self' 'unsafe-inline'"
+    },
     modulePrefix: 'mdeditor',
     podModulePrefix: 'mdeditor/pods',
     environment: environment,

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "ember-cli-htmlbars-inline-precompile": "^0.3.1",
     "ember-cli-ic-ajax": "0.2.4",
     "ember-cli-inject-live-reload": "^1.3.1",
-    "ember-cli-moment-shim": "1.1.0",
     "ember-cli-qunit": "^1.0.4",
     "ember-cli-release": "0.2.8",
     "ember-cli-sass": "5.2.1",

--- a/package.json
+++ b/package.json
@@ -47,5 +47,8 @@
     "ember-try": "0.0.8",
     "mdcodes": "^1.2.3",
     "node-uuid": "^1.4.7"
+  },
+  "dependencies": {
+    "validator": "^5.3.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "ember-cli-htmlbars-inline-precompile": "^0.3.1",
     "ember-cli-ic-ajax": "0.2.4",
     "ember-cli-inject-live-reload": "^1.3.1",
+    "ember-cli-moment-shim": "1.3.0",
     "ember-cli-qunit": "^1.0.4",
     "ember-cli-release": "0.2.8",
     "ember-cli-sass": "5.2.1",

--- a/tests/acceptance/pods/contact/new-test.js
+++ b/tests/acceptance/pods/contact/new-test.js
@@ -14,7 +14,7 @@ test('test new contact initial page conditions', function(assert) {
   assert.expect(5);
   visit('/contact/new');
   andThen(function() {
-    assert.equal(find('input:eq(0)').val().length, 6);
+    assert.equal(find('input:eq(0)').val().length, 36);
     assert.equal(find('input:eq(1)').val(), "");
     assert.equal(find('input:eq(2)').val(), "");
     assert.equal(find('button.md-form-save').prop('disabled'), true);

--- a/tests/acceptance/pods/contact/new-test.js
+++ b/tests/acceptance/pods/contact/new-test.js
@@ -5,16 +5,64 @@ moduleForAcceptance('Acceptance | pods/contact/new');
 
 test('visiting /pods/contact/new', function(assert) {
   visit('/contact/new');
-
   andThen(function() {
     assert.equal(currentURL(), '/contact/new');
   });
-  
 });
 
-test('should have default contact ID', function(assert) {
+test('test new contact initial page conditions', function(assert) {
+  assert.expect(5);
   visit('/contact/new');
   andThen(function() {
-    assert.equal(find('input.first').text().length, 6);
+    assert.equal(find('input:eq(0)').val().length, 6);
+    assert.equal(find('input:eq(1)').val(), "");
+    assert.equal(find('input:eq(2)').val(), "");
+    assert.equal(find('button.md-form-save').prop('disabled'), true);
+    assert.equal(find('div.md-form-alert').length, 1);
+  });
+});
+
+test('test new contact individual', function (assert) {
+  assert.expect(3);
+  visit('/contact/new');
+  fillIn('input:eq(1)', 'Individual Name');
+  andThen(function() {
+    assert.equal(find('input:eq(1)').val(), "Individual Name");
+    assert.equal(find('button.md-form-save').prop('disabled'), false);
+    assert.equal(find('div.md-form-alert').length, 0);
+  });
+});
+
+test('test new contact organization', function (assert) {
+  assert.expect(3);
+  visit('/contact/new');
+  fillIn('input:eq(2)', 'Organization Name');
+  andThen(function() {
+    assert.equal(find('input:eq(2)').val(), "Organization Name");
+    assert.equal(find('button.md-form-save').prop('disabled'), false);
+    assert.equal(find('div.md-form-alert').length, 0);
+  });
+});
+
+test('test new contact organization and individual names', function (assert) {
+  assert.expect(2);
+  visit('/contact/new');
+  fillIn('input:eq(1)', 'Individual Name');
+  fillIn('input:eq(2)', 'Organization Name');
+  andThen(function() {
+    assert.equal(find('button.md-form-save').prop('disabled'), false);
+    assert.equal(find('div.md-form-alert').length, 0);
+  });
+});
+
+test('test new contact missing contact ID', function (assert) {
+  assert.expect(2);
+  visit('/contact/new');
+  fillIn('input:eq(0)', '');
+  fillIn('input:eq(1)', 'Individual Name');
+  fillIn('input:eq(2)', 'Organization Name');
+  andThen(function() {
+    assert.equal(find('button.md-form-save').prop('disabled'), true);
+    assert.equal(find('div.md-form-alert').length, 1);
   });
 });

--- a/tests/acceptance/pods/contact/new-test.js
+++ b/tests/acceptance/pods/contact/new-test.js
@@ -1,0 +1,20 @@
+import { test } from 'qunit';
+import moduleForAcceptance from 'mdeditor/tests/helpers/module-for-acceptance';
+
+moduleForAcceptance('Acceptance | pods/contact/new');
+
+test('visiting /pods/contact/new', function(assert) {
+  visit('/contact/new');
+
+  andThen(function() {
+    assert.equal(currentURL(), '/contact/new');
+  });
+  
+});
+
+test('should have default contact ID', function(assert) {
+  visit('/contact/new');
+  andThen(function() {
+    assert.equal(find('input.first').text().length, 6);
+  });
+});

--- a/tests/acceptance/pods/dictionary/new-test.js
+++ b/tests/acceptance/pods/dictionary/new-test.js
@@ -1,0 +1,56 @@
+import { test } from 'qunit';
+import moduleForAcceptance from 'mdeditor/tests/helpers/module-for-acceptance';
+
+moduleForAcceptance('Acceptance | pods/dictionary/new');
+
+test('visiting /pods/dictionary/new', function(assert) {
+  visit('/dictionary/new');
+  andThen(function() {
+    assert.equal(currentURL(), '/dictionary/new');
+  });
+});
+
+test('test new dictionary initial page conditions', function(assert) {
+  assert.expect(4);
+  visit('/dictionary/new');
+  andThen(function() {
+    assert.equal(find('input:eq(0)').val(), "");
+    assert.equal(find('div.md-form-select select').val(), "");
+    assert.equal(find('button.md-form-save').prop('disabled'), true);
+    assert.equal(find('div.md-form-alert').length, 2);
+  });
+});
+
+test('test new dictionary completed form', function (assert) {
+  assert.expect(4);
+  visit('/dictionary/new');
+  fillIn('input:eq(0)', 'Dictionary Name');
+  fillIn('div.md-form-select select', 'aggregate');
+  andThen(function() {
+    assert.equal(find('input:eq(0)').val(), "Dictionary Name");
+    assert.equal(find('div.md-form-select select').val(), "aggregate");
+    assert.equal(find('button.md-form-save').prop('disabled'), false);
+    assert.equal(find('div.md-form-alert').length, 0);
+  });
+});
+
+test('test new dictionary missing dictionary name', function (assert) {
+  assert.expect(2);
+  visit('/dictionary/new');
+  fillIn('div.md-form-select select', 'aggregate');
+  andThen(function() {
+    assert.equal(find('button.md-form-save').prop('disabled'), true);
+    assert.equal(find('div.md-form-alert').length, 1);
+  });
+});
+
+test('test new dictionary missing data resource type', function (assert) {
+  assert.expect(2);
+  visit('/dictionary/new');
+  fillIn('input:eq(0)', 'Dictionary Name');
+  andThen(function() {
+    assert.equal(find('button.md-form-save').prop('disabled'), true);
+    assert.equal(find('div.md-form-alert').length, 1);
+  });
+});
+

--- a/tests/acceptance/pods/record/new-test.js
+++ b/tests/acceptance/pods/record/new-test.js
@@ -1,0 +1,55 @@
+import { test } from 'qunit';
+import moduleForAcceptance from 'mdeditor/tests/helpers/module-for-acceptance';
+
+moduleForAcceptance('Acceptance | pods/record/new');
+
+test('visiting /pods/record/new', function(assert) {
+  visit('/record/new');
+  andThen(function() {
+    assert.equal(currentURL(), '/record/new');
+  });
+});
+
+test('test new mdJSON record initial page conditions', function(assert) {
+  assert.expect(4);
+  visit('/record/new');
+  andThen(function() {
+    assert.equal(find('input:eq(0)').val(), "");
+    assert.equal(find('div.md-form-select select').val(), "");
+    assert.equal(find('button.md-form-save').prop('disabled'), true);
+    assert.equal(find('div.md-form-alert').length, 2);
+  });
+});
+
+test('test new mdJSON record completed form', function (assert) {
+  assert.expect(4);
+  visit('/record/new');
+  fillIn('input:eq(0)', 'Record Title');
+  fillIn('div.md-form-select select', 'attribute');
+  andThen(function() {
+    assert.equal(find('input:eq(0)').val(), "Record Title");
+    assert.equal(find('div.md-form-select select').val(), "attribute");
+    assert.equal(find('button.md-form-save').prop('disabled'), false);
+    assert.equal(find('div.md-form-alert').length, 0);
+  });
+});
+
+test('test new mdJSON record missing record title', function (assert) {
+  assert.expect(2);
+  visit('/record/new');
+  fillIn('div.md-form-select select', 'attribute');
+  andThen(function() {
+    assert.equal(find('button.md-form-save').prop('disabled'), true);
+    assert.equal(find('div.md-form-alert').length, 1);
+  });
+});
+
+test('test new mdJSON record missing data record type (scope)', function (assert) {
+  assert.expect(2);
+  visit('/record/new');
+  fillIn('input:eq(0)', 'Record Title');
+  andThen(function() {
+    assert.equal(find('button.md-form-save').prop('disabled'), true);
+    assert.equal(find('div.md-form-alert').length, 1);
+  });
+});

--- a/tests/unit/pods/contacts/route-test.js
+++ b/tests/unit/pods/contacts/route-test.js
@@ -1,11 +1,38 @@
 import { moduleFor, test } from 'ember-qunit';
 
+let originalConfirm;
+
 moduleFor('route:contacts', 'Unit | Route | contacts', {
-  // Specify the other units that are required for this test.
-  // needs: ['controller:foo']
+  beforeEach() {
+    originalConfirm = window.confirm;
+  },
+
+  afterEach() {
+    window.confirm = originalConfirm;
+  }
 });
 
 test('it exists', function(assert) {
   var route = this.subject();
   assert.ok(route);
+});
+
+test('should display a confirm', function(assert) {
+  assert.expect(2);
+
+  let route = this.subject();
+
+  // test _deleteItem to displays the expected window.confirm message
+  const expectedTextFoo = 'foo';
+  window.confirm = (message) => {
+    assert.equal(message, expectedTextFoo, 'expect confirm to display ${expectedTextFoo}');
+  };
+  route._deleteItem(0, expectedTextFoo);
+
+  // test action deleteItem calls _deleteItem and displays a window.confirm
+  window.confirm = (message) => {
+    assert.ok(message, 'expect confirm to display a message');
+  };
+  route.send('deleteItem', 0);
+  
 });

--- a/tests/unit/pods/dictionaries/route-test.js
+++ b/tests/unit/pods/dictionaries/route-test.js
@@ -1,11 +1,39 @@
 import { moduleFor, test } from 'ember-qunit';
 
+let originalConfirm;
+
 moduleFor('route:dictionaries', 'Unit | Route | dictionaries', {
-  // Specify the other units that are required for this test.
-  // needs: ['controller:foo']
+  beforeEach() {
+    originalConfirm = window.confirm;
+  },
+  
+  afterEach() {
+    window.confirm = originalConfirm;
+  }
 });
 
 test('it exists', function(assert) {
   var route = this.subject();
   assert.ok(route);
 });
+
+test('should display a confirm', function(assert) {
+  assert.expect(2);
+  
+  let route = this.subject();
+  
+  // test _deleteItem to displays the expected window.confirm message
+  const expectedTextFoo = 'foo';
+  window.confirm = (message) => {
+    assert.equal(message, expectedTextFoo, 'expect confirm to display ${expectedTextFoo}');
+  };
+  route._deleteItem(0, expectedTextFoo);
+  
+  // test action deleteItem calls _deleteItem and displays a window.confirm
+  window.confirm = (message) => {
+    assert.ok(message, 'expect confirm to display a message');
+  };
+  route.send('deleteItem', 0);
+  
+});
+

--- a/tests/unit/pods/records/route-test.js
+++ b/tests/unit/pods/records/route-test.js
@@ -1,11 +1,38 @@
 import { moduleFor, test } from 'ember-qunit';
 
+let originalConfirm;
+
 moduleFor('route:records', 'Unit | Route | records', {
-  // Specify the other units that are required for this test.
-  // needs: ['controller:foo']
+  beforeEach() {
+    originalConfirm = window.confirm;
+  },
+  
+  afterEach() {
+    window.confirm = originalConfirm;
+  }
 });
 
 test('it exists', function(assert) {
   var route = this.subject();
   assert.ok(route);
+});
+
+test('should display a confirm', function(assert) {
+  assert.expect(2);
+  
+  let route = this.subject();
+  
+  // test _deleteItem to displays the expected window.confirm message
+  const expectedTextFoo = 'foo';
+  window.confirm = (message) => {
+    assert.equal(message, expectedTextFoo, 'expect confirm to display ${expectedTextFoo}');
+  };
+  route._deleteItem(0, expectedTextFoo);
+  
+  // test action deleteItem calls _deleteItem and displays a window.confirm
+  window.confirm = (message) => {
+    assert.ok(message, 'expect confirm to display a message');
+  };
+  route.send('deleteItem', 0);
+  
 });


### PR DESCRIPTION
Added code for creating new contact, dictionary, and mdJSON records.  

After new records are saved to data store, the records is opened in edit mode. Includes acceptance tests. Closes issue #32. 