### PR TITLE
Added custom CSS to .md-input-input selector in app/styles/_form_elem…

### DIFF
--- a/app/styles/_form_elements.scss
+++ b/app/styles/_form_elements.scss
@@ -108,6 +108,10 @@ form {
 //to display error icons
 .md-input-input {
   position: relative;
+  > input[placeholder] {
+    text-overflow: ellipsis;
+    padding-right: 30px;
+  }
 }
 
 .md-datetime {


### PR DESCRIPTION
### Added custom CSS to .md-input-input selector in app/styles/_form_elements.scss to truncate overflow text and leave validation warning on top for visibility.

![Screenshot from 2019-10-27 16-08-53](https://user-images.githubusercontent.com/24277002/67641523-ffd0a900-f8d8-11e9-9b32-6c0a53c83d09.png)


```
.md-input-input {
  position: relative;
  > input[placeholder] {
    text-overflow: ellipsis;
    padding-right: 30px;
  }
}
```


