### PR TITLE
pointing the editor at the production sciencebase translator instance

### DIFF
--- a/app/models/setting.js
+++ b/app/models/setting.js
@@ -5,8 +5,7 @@ import DS from 'ember-data';
 import EmberObject, { observer } from "@ember/object";
 
 const defaultValues = {
-  // mdTranslatorAPI: 'https://mdtranslator.herokuapp.com/api/v3/translator',
-  mdTranslatorAPI: 'https://md-translator.onrender.com/api/v3/translator',
+  mdTranslatorAPI: 'https://api.sciencebase.gov/mdTranslator/api/v3/translator',
   fiscalStartMonth: '10'
 };
 


### PR DESCRIPTION
translation on go.mdeditor.org is pointed at heroku, which is now permanently offline

this points the editor's translation service at [api.sciencebase.gov/mdtranslator](https://api.sciencebase.gov/mdTranslator)