### PR TITLE
add multistage Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+bower_components
+node_modules
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM node:14 as build
+WORKDIR /src
+
+COPY package.json /src/.
+COPY yarn.lock /src/.
+
+RUN yarn install
+
+COPY . /src/.
+RUN yarn build
+
+# Final image will only contain the following
+FROM pierrezemb/gostatic
+COPY --from=build /src/dist/ /srv/http/
+
+CMD ["-fallback", "/index.html"]


### PR DESCRIPTION
This might be helpful in some hosting environments

[Mulit-stage builds](https://docs.docker.com/build/building/multi-stage/) - basically the final image will only contain static files in /dist and a web server ~29MB in size

