### PR TITLE
add a default value for externalIdentifiers, since imported contacts won't have it set

### DIFF
--- a/app/pods/components/object/md-contact-identifier-array/component.js
+++ b/app/pods/components/object/md-contact-identifier-array/component.js
@@ -23,16 +23,24 @@ const Validations = buildValidations({
 export default Component.extend({
 
   /**
-   * mdEditor class for input and edit of mdJSON 'phone' object.
-   * The class manages the maintenance of an array of phone objects.
+   * mdEditor class for input and edit of mdJSON 'externalIdentifiers' object.
+   * The class manages the maintenance of an array of phone externalIdentifiers.
    *
-   * @class md-phone-array
+   * @class md-contact-identfier-array
    * @module mdeditor
    * @submodule components-object
    * @constructor
    */
 
   attributeBindings: ['data-spy'],
+
+  init() {
+    this._super(...arguments);
+
+    if (!this.value) {
+      this.value = [];
+    }
+  },
 
   /**
    * See [md-array-table](md-array-table.html#property_templateClass).


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix


* **What is the current behavior?** (You can also link to an open issue here)
Imported contacts are unable to have External Identifiers set


* **What is the new behavior (if this is a feature change)?**
Imported contacts are able to have External Identifiers set


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No

