### PR TITLE
Feature/itis proxy

### DIFF
--- a/app/services/itis.js
+++ b/app/services/itis.js
@@ -117,11 +117,9 @@ export default Service.extend({
     let titleized = titleize(searchString.replace(/(-)/g, '#')).replace(/( |#)/g, '*');
     let titleized2 = titleize(searchString).replace(/( )/g, '*');
 
-    const mdTranslatorAPIURL = new URL(this.settings.data.get('mdTranslatorAPI'))
-    const host = mdTranslatorAPIURL.hostname;
-    const port = mdTranslatorAPIURL.port;
+    const baseUrl = this.settings.data.get('mdTranslatorAPI').replace('/api/v3/translator', '')
 
-    let url = '//' + host + (port === '' ? port : ':' + port) + proxy +
+    let url = baseUrl + proxy +
       `&rows=${limit}&q=` +
       `(vernacular:*${formatted}*~0.5%20OR%20vernacular:*${titleized}*~0.5%20OR%20vernacular:*${titleized2}*~0.5` +
       `%20OR%20nameWOInd:${formatted}*~0.5%20OR%20nameWOInd:*${titleized}*~0.5` +

--- a/app/services/itis.js
+++ b/app/services/itis.js
@@ -11,7 +11,7 @@ import {
 const console = window.console;
 
 const proxy =
-  'https://itis-cors.herokuapp.com/https://services.itis.gov?' +
+  '/itis-proxy?' +
   'wt=json' +
   '&sort=score%20desc,nameWOInd%20asc' +
   '&fl=hierarchySoFarWRanks,hierarchyTSN,kingdom,rank,vernacular,tsn,nameWOInd,usage';
@@ -107,6 +107,7 @@ export default Service.extend({
     })
   },
 
+  settings: service(),
   ajax: service(),
   flashMessages: service(),
   isLoading: false,
@@ -115,7 +116,12 @@ export default Service.extend({
     let formatted = searchString.replace(/(-| )/g, '*');
     let titleized = titleize(searchString.replace(/(-)/g, '#')).replace(/( |#)/g, '*');
     let titleized2 = titleize(searchString).replace(/( )/g, '*');
-    let url = proxy +
+
+    const mdTranslatorAPIURL = new URL(this.settings.data.get('mdTranslatorAPI'))
+    const host = mdTranslatorAPIURL.hostname;
+    const port = mdTranslatorAPIURL.port;
+
+    let url = '//' + host + (port === '' ? port : ':' + port) + proxy +
       `&rows=${limit}&q=` +
       `(vernacular:*${formatted}*~0.5%20OR%20vernacular:*${titleized}*~0.5%20OR%20vernacular:*${titleized2}*~0.5` +
       `%20OR%20nameWOInd:${formatted}*~0.5%20OR%20nameWOInd:*${titleized}*~0.5` +


### PR DESCRIPTION
update to use the new itis api proxy through the translator

```bash
## Request (7)
curl "https://dev-translator.mdeditor.org/itis-proxy?wt=json&sort=score%20desc,nameWOInd%20asc&fl=hierarchySoFarWRanks,hierarchyTSN,kingdom,rank,vernacular,tsn,nameWOInd,usage&rows=25&q=(vernacular%3A*asdf*~0.5%20OR%20vernacular%3A*Asdf*~0.5%20OR%20vernacular%3A*Asdf*~0.5%20OR%20nameWOInd%3Aasdf*~0.5%20OR%20nameWOInd%3A*Asdf*~0.5%20OR%20tsn%3Aasdf)"
```

To test in the UI, you'll need to change the Settings > mdTranslator API URL to
`https://dev-translator.mdeditor.org/api/v3/translator`