### PR TITLE
fix for imported and existing contacts not able to add external identifiers

### DIFF
--- a/app/pods/components/object/md-contact-identifier-array/component.js
+++ b/app/pods/components/object/md-contact-identifier-array/component.js
@@ -1,5 +1,5 @@
 import Component from '@ember/component';
-import EmObject from '@ember/object';
+import EmObject, { set } from '@ember/object';
 import { A } from '@ember/array';
 import {
   validator,
@@ -38,7 +38,7 @@ export default Component.extend({
     this._super(...arguments);
 
     if (!this.value) {
-      this.value = [];
+      set(this, 'value', A())
     }
   },
 

--- a/app/pods/components/object/md-contact-identifier-array/template.hbs
+++ b/app/pods/components/object/md-contact-identifier-array/template.hbs
@@ -7,7 +7,8 @@
   templateClass=templateClass as |contactId|
 }}
   <td>
-      {{input/md-input valuePath="identifier" model=contactId.item
+      {{input/md-input
+        value=contactId.item.identifier
       placeholder="External Contact Identifier"}}
   </td>
   <td>

--- a/app/services/patch.js
+++ b/app/services/patch.js
@@ -29,6 +29,10 @@ export default Service.extend({
 
       record.set('json.memberOfOrganization', A(record.get(
         'json.memberOfOrganization')).uniq());
+
+      if(record.get('json.externalIdentifier') == null) {
+        record.set('json.externalIdentifier', A());
+      }
       record.save().then(function () {
         record.notifyPropertyChange('currentHash');
       });


### PR DESCRIPTION
I think a default value needed to be set for ember to see changes to contact.externalIdentifier on imported contacts

I'm not super sure this is the best way to fix it...