### PR TITLE
Refactor copy for data dictionary (#572)

### DIFF
--- a/app/models/dictionary.js
+++ b/app/models/dictionary.js
@@ -133,19 +133,13 @@ export default Model.extend(Validations, Copyable, {
     return errors;
   }),
 
-  assignId(force) {
-    if(force || !this.dictionaryId) {
-      this.set('json.dictionaryId', uuidV4());
-    }
-  },
-
   copy() {
     let current = this.cleanJson;
     let json = EmberObject.create(current);
     let name = current.dataDictionary.citation.title;
-
+    console.log(json)
     json.set('dataDictionary.citation.title', `Copy of ${name}`);
-    this.assignId(true);
+    json.set('dictionaryId', uuidV4());
 
     return this.store.createRecord('dictionary', {
       json: json


### PR DESCRIPTION
### Closing issues

closes #572 

## Pull Request

* **Please check if the PR fulfills these requirements**
  - [x] The commit message follows our guidelines
  - [x] Tests for the changes have been added (for bug fixes/features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
When copying a data dictionary it will now create new uuid


* **What is the current behavior?** (You can also link to an open issue here)
#572


* **What is the new behavior (if this is a feature change)?**
Data dictionary gets a new ID whenever copied


* **Other information**:
<img width="749" alt="image" src="https://github.com/adiwg/mdEditor/assets/24277002/594d456b-cf99-4fb4-8221-ddb9e09c2d8e">
<img width="749" alt="Screenshot 2023-08-08 at 11 06 54" src="https://github.com/adiwg/mdEditor/assets/24277002/bf6a218b-c183-487c-aad7-003198c2a753">
