### PR TITLE
Update mdTranslator URL

### DIFF
--- a/app/models/setting.js
+++ b/app/models/setting.js
@@ -6,7 +6,7 @@ import EmberObject, { observer } from "@ember/object";
 
 const defaultValues = {
   // mdTranslatorAPI: 'https://api.sciencebase.gov/mdTranslator/api/v3/translator',
-  mdTranslatorAPI: 'https://data-quality.md-translator.tzwolak.com/api/v3/translator',
+  mdTranslatorAPI: 'https://dev-mdtranslator.mdeditor.org/api/v3/translator',
   fiscalStartMonth: '10'
 };
 


### PR DESCRIPTION
Closes #586 

Changes:
Update mdTranslator URL to https://dev-mdtranslator.mdeditor.org/api/v3/tranlator
Remove old mdTranslator URL