### PR TITLE
Fix Itis Proxy

### DIFF
--- a/app/models/setting.js
+++ b/app/models/setting.js
@@ -5,10 +5,10 @@ import { inject as service } from '@ember/service';
 import EmberObject, { observer } from "@ember/object";
 
 const defaultValues = {
-  // mdTranslatorAPI: 'https://api.sciencebase.gov/mdTranslator/api/v3/translator',
-  // itisProxyUrl: 'https://api.sciencebase.gov/mdTranslator',
-  mdTranslatorAPI: 'https://dev-mdtranslator.mdeditor.org/api/v3/translator',
-  itisProxyUrl: 'https://dev-mdtranslator.mdeditor.org',
+  mdTranslatorAPI: 'https://api.sciencebase.gov/mdTranslator/api/v3/translator',
+  itisProxyUrl: 'https://api.sciencebase.gov/mdTranslator',
+  // mdTranslatorAPI: 'https://dev-mdtranslator.mdeditor.org/api/v3/translator',
+  // itisProxyUrl: 'https://dev-mdtranslator.mdeditor.org',
   fiscalStartMonth: '10'
 };
 

--- a/app/models/setting.js
+++ b/app/models/setting.js
@@ -6,7 +6,9 @@ import EmberObject, { observer } from "@ember/object";
 
 const defaultValues = {
   // mdTranslatorAPI: 'https://api.sciencebase.gov/mdTranslator/api/v3/translator',
+  // itisProxyUrl: 'https://api.sciencebase.gov/mdTranslator',
   mdTranslatorAPI: 'https://dev-mdtranslator.mdeditor.org/api/v3/translator',
+  itisProxyUrl: 'https://dev-mdtranslator.mdeditor.org',
   fiscalStartMonth: '10'
 };
 
@@ -72,6 +74,9 @@ const theModel = Model.extend({
   }),
   mdTranslatorAPI: attr('string', {
     defaultValue: defaultValues.mdTranslatorAPI
+  }),
+  itisProxyUrl: attr('string', {
+    defaultValue: defaultValues.itisProxyUrl
   }),
   fiscalStartMonth: attr('string', {
     defaultValue: defaultValues.fiscalStartMonth

--- a/app/services/itis.js
+++ b/app/services/itis.js
@@ -113,15 +113,12 @@ export default Service.extend({
   isLoading: false,
 
   sendQuery(searchString, kingdom, limit = 50) {
-    let formatted = searchString.replace(/(-| )/g, '*');
-    let titleized = titleize(searchString.replace(/(-)/g, '#')).replace(/( |#)/g, '*');
-    let titleized2 = titleize(searchString).replace(/( )/g, '*');
+    const formatted = searchString.replace(/(-| )/g, '*');
+    const titleized = titleize(searchString.replace(/(-)/g, '#')).replace(/( |#)/g, '*');
+    const titleized2 = titleize(searchString).replace(/( )/g, '*');
 
-    const mdTranslatorAPIURL = new URL(this.settings.data.get('mdTranslatorAPI'))
-    const host = mdTranslatorAPIURL.hostname;
-    const port = mdTranslatorAPIURL.port;
-
-    let url = '//' + host + (port === '' ? port : ':' + port) + proxy +
+    const mdTranslatorApiUrl = this.settings.data.get('itisProxyUrl');
+    const url = mdTranslatorApiUrl + proxy +
       `&rows=${limit}&q=` +
       `(vernacular:*${formatted}*~0.5%20OR%20vernacular:*${titleized}*~0.5%20OR%20vernacular:*${titleized2}*~0.5` +
       `%20OR%20nameWOInd:${formatted}*~0.5%20OR%20nameWOInd:*${titleized}*~0.5` +
@@ -174,13 +171,13 @@ export default Service.extend({
       vernacular,
       usage: status
     } = doc;
-    let taxonomy = this.parseRanks(ranks, this.parseHierarchyTSN(
+    const taxonomy = this.parseRanks(ranks, this.parseHierarchyTSN(
       hierarchyTSN));
-    let common = this.parseVernacular(vernacular);
+      const common = this.parseVernacular(vernacular);
 
     if(common) {
       taxonomy.forEach(i => {
-        let taxa = i.findBy('tsn', tsn);
+        const taxa = i.findBy('tsn', tsn);
 
         if(taxa) {
           set(taxa, 'common', common.mapBy('name'));


### PR DESCRIPTION
Closes #621, closes #503 

### [Test instance available here](http://44.211.70.63:8001/)

# Changes

`app/models/setting.js` has a new value for the itis proxy url. If desired, we could add a UI element for this.
`app/services/itis.js` was refactored to use the new itis proxy url.

The itis service was extracting the hostname from the api url and building the url from there. This caused a problem for the mdTranslator deployed in ScienceBase because they add the `mdTranslator/` path, which was not accounted for, so the itis proxy was working in dev but not in prod.

## No breaking changes