### PR TITLE
Removed code that was setting the `dictionaryID` on the record that wasn't needed.

### DIFF
--- a/app/services/mdjson.js
+++ b/app/services/mdjson.js
@@ -119,15 +119,8 @@ export default Service.extend({
 
       let dicts = this.store.peekAll('dictionary').filterBy(
         'dictionaryId');
-
       ids.forEach((id) => {
         let record = dicts.findBy('dictionaryId', id);
-
-        // dictionaryId is important, but it's not in "dataDictionary" - I feel like it
-        // should be included so the id can be stable when importing/exporting
-        //
-        // fixes https://github.com/adiwg/mdTranslator/issues/238
-        record.set('json.dataDictionary.dictionaryId', id);
 
         if(record) {
           arr.pushObject(record.get('json.dataDictionary'));
@@ -248,6 +241,7 @@ export default Service.extend({
   validateDictionary(dictionary) {
     validator.validate('dataDictionary', dictionary.get('cleanJson').dataDictionary);
 
+    console.log(validator)
     return validator;
   }
 });


### PR DESCRIPTION
### Closing issues

closes #558 

## Pull Request

* **Please check if the PR fulfills these requirements**
  - [x] The commit message follows our guidelines
~~- [ ] Tests for the changes have been added (for bug fixes / features)~~
~~- [ ] Docs have been added / updated (for bug fixes / features)~~


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix for importing a Record that may have a associated contact, or dictionary, but would not allow the user to edit the record afterwards.  There were also instances of the record not displaying in the sidebar nav


* **What is the current behavior?** (You can also link to an open issue here)
Behavior works as designed


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?) no



* **Other information**:

https://github.com/adiwg/mdEditor/assets/24277002/8a6e2751-72a9-4f04-8a99-33708be1e840


