### PR TITLE
Release Version 1.2.0-dev.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mdeditor",
-  "version": "1.2.0-dev.1",
+  "version": "1.2.0-dev.2",
   "description": "A web application for authoring and editing metadata.",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -143,7 +143,7 @@
     "liquid-fire": "~0.31.0",
     "loader.js": "^4.7.0",
     "mdcodes": "2.8.4",
-    "mdjson-schemas": "2.8.2",
+    "mdjson-schemas": "2.8.1",
     "moment": "^2",
     "moment-timezone": "^0.5.27",
     "object-hash": "^2.0.1",

--- a/public/404.html
+++ b/public/404.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <title>mdEditor</title>
+    <meta name="description" content="The mdEditor is a web application that allows users to author and edit metadata for projects and datasets.">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+
+    {{content-for "head"}}
+
+    <link rel="stylesheet" href="{{rootURL}}assets/vendor.css">
+    <link rel="stylesheet" href="{{rootURL}}assets/mdeditor.css">
+
+    <link rel="apple-touch-icon-precomposed" sizes="144x144" href="{{rootURL}}apple-touch-icon-144x144.png" />
+    <link rel="apple-touch-icon-precomposed" sizes="152x152" href="{{rootURL}}apple-touch-icon-152x152.png" />
+    <link rel="icon" type="image/png" href="{{rootURL}}favicon-32x32.png" sizes="32x32" />
+    <link rel="icon" type="image/png" href="{{rootURL}}favicon-16x16.png" sizes="16x16" />
+    <meta name="application-name" content="mdEditor - the friendly metadata editor"/>
+    <meta name="msapplication-TileColor" content="#FFFFFF" />
+    <meta name="msapplication-TileImage" content="{{rootURL}}mstile-144x144.png" />
+
+    <!-- Redirect Script -->
+    <!-- <script type="text/javascript">
+      if(document.location.host + document.location.pathname === 'www.adiwg.org/mdEditor/') {
+        document.location.replace('https://go.mdeditor.org');
+      }
+    </script> -->
+
+    {{content-for "head-footer"}}
+  </head>
+  <body>
+    {{content-for "body"}}
+    <div class="md-load-indicator">
+      <div class="md-load-wrapper">
+        <div class="md-load-spinner">
+          <div></div>
+          <div></div>
+        </div>
+      </div>
+      <h3>Loading <span class="text-primary">mdEditor</span>...might take a few seconds ;)</h3>
+    </div>
+
+    <script src="{{rootURL}}assets/vendor.js"></script>
+    <script src="{{rootURL}}assets/mdeditor.js"></script>
+
+    {{content-for "body-footer"}}
+  </body>
+</html>

--- a/yarn.lock
+++ b/yarn.lock
@@ -10871,10 +10871,10 @@ mdcodes@2.8.4:
     glob "^7.1.0"
     rimraf "^2.6.2"
 
-mdjson-schemas@2.8.2:
-  version "2.8.2"
-  resolved "https://registry.yarnpkg.com/mdjson-schemas/-/mdjson-schemas-2.8.2.tgz#87b83255cccf116c3244fe262ec0b784b80ce861"
-  integrity sha512-OaJiXTKptekUenGL7NV4PGW231x/enlo5tvWDx/ox0iMbuydLP8Jl6ypeHU0Sd9Gze9iSJL9tkoWpTm7wm+34Q==
+mdjson-schemas@2.8.1:
+  version "2.8.1"
+  resolved "https://registry.yarnpkg.com/mdjson-schemas/-/mdjson-schemas-2.8.1.tgz#809131dce1e172ac81f035611f98276bc41635c8"
+  integrity sha512-VfYeSCLo3mCFmd17csplpk4QmZEubOZ64odv+ZzDow+pjzJgXeqMV9EYZFuEKxXc65ioahi5OMXotcvNaHi4tg==
 
 mdn-data@2.0.30:
   version "2.0.30"


### PR DESCRIPTION
Closes #648 

# Changes

Downgrade mdJson-schemas to 2.8.1 (same as the current production mdTranslator uses)

Add public/404.html to support non-hashed urls in GitHub pages


### Testing

https://dev.mdeditor.org/