### PR TITLE
Use Ember internal Id as UUID for records, dictionaries, and dictionaries

### DIFF
--- a/app/models/contact.js
+++ b/app/models/contact.js
@@ -13,8 +13,6 @@ import EmberObject, {
 import {
   Copyable
 } from 'ember-copy'
-import uuidV4 from 'uuid/v4';
-import Validator from 'validator';
 import Model from 'mdeditor/models/base';
 import {
   validator,
@@ -37,7 +35,7 @@ const Validations = buildValidations({
       message: "Name should not be only white-space."
     }),
     validator('presence', {
-      disabled: notEmpty('model.json.positionName'),
+      disabled: notEmpty('model.json.name'),
       presence: true
     })
   ],
@@ -49,7 +47,7 @@ const Validations = buildValidations({
       message: "Position Name should not be only white-space."
     }),
     validator('presence', {
-      disabled: notEmpty('model.json.name'),
+      disabled: notEmpty('model.json.postiionName'),
       presence: true
     })
   ],
@@ -63,10 +61,10 @@ const JsonDefault = EmberObject.extend({
   init() {
     this._super(...arguments);
     this.setProperties({
-      'contactId': uuidV4(),
+      'contactId': null,
       'isOrganization': false,
       'name': null,
-      //'positionName': null,
+      'positionName': null,
       'memberOfOrganization': [],
       'logoGraphic': [],
       'phone': [],
@@ -75,8 +73,6 @@ const JsonDefault = EmberObject.extend({
       'externalIdentifier': [],
       'onlineResource': [],
       'hoursOfService': [],
-      //'contactInstructions': null,
-      //'contactType': null;
     });
   }
 });
@@ -148,37 +144,6 @@ const Contact = Model.extend(Validations, Copyable, {
 
       return json.name || (json.isOrganization ? null : json.positionName);
     }),
-
-  // /**
-  //  * The formatted display string for the contact
-  //  *
-  //  * @property title
-  //  * @type {String}
-  //  * @readOnly
-  //  * @category computed
-  //  * @requires json.name, json.positionName
-  //  */
-  // updateMembers: Ember.observer('json.memberOfOrganization.[]',
-  //   function () {
-  //     //const me = this;
-  //     const json = this.get('json');
-  //     const value = json.memberOfOrganization;
-  //
-  //     let store = this.get('store');
-  //     let contacts = store.peekAll('contact');
-  //     let organizations = this.get('organizations')
-  //       .clear();
-  //
-  //     value.forEach(function (id) {
-  //       let rec = contacts.findBy('json.contactId', id);
-  //
-  //       if(rec) {
-  //         organizations.pushObject(rec);
-  //       }
-  //       //rec.get('contacts').pushObject(me);
-  //     });
-  //
-  //   }),
 
   /**
    * The type of contact
@@ -319,26 +284,6 @@ const Contact = Model.extend(Validations, Copyable, {
     }),
 
   /**
-   * The trimmed varsion of the contactId.
-   *
-   * @property shortId
-   * @type {String}
-   * @readOnly
-   * @category computed
-   * @requires json.contactId
-   */
-  shortId: computed('json.contactId', function () {
-    const contactId = this.get('json.contactId');
-    if(contactId && Validator.isUUID(contactId)) {
-      let index = contactId.indexOf('-');
-
-      return contactId.substring(0, index);
-    }
-
-    return contactId;
-  }),
-
-  /**
    * A list of schema errors return by the validator.
    *
    * @property schemaErrors
@@ -395,7 +340,7 @@ const Contact = Model.extend(Validations, Copyable, {
       isOrganization: isOrganization,
       name: name ? `Copy of ${name}` : null,
       positionName: name ? positionName : `Copy of ${positionName}`,
-      contactId: uuidV4()
+      contactId: null,
     });
 
     return this.store.createRecord('contact', {

--- a/app/models/dictionary.js
+++ b/app/models/dictionary.js
@@ -1,6 +1,5 @@
 import { attr } from '@ember-data/model';
 import { Copyable } from 'ember-copy'
-import uuidV4 from "uuid/v4";
 import { alias } from '@ember/object/computed';
 import Model from 'mdeditor/models/base';
 import {
@@ -40,7 +39,7 @@ const JsonDefault = EmberObject.extend({
   init() {
     this._super(...arguments);
     this.setProperties({
-      dictionaryId: uuidV4(),
+      dictionaryId: null,
       dataDictionary: {
         citation: {
           title: null,
@@ -138,7 +137,7 @@ export default Model.extend(Validations, Copyable, {
     let json = EmberObject.create(current);
     let name = current.dataDictionary.citation.title;
     json.set('dataDictionary.citation.title', `Copy of ${name}`);
-    json.set('dictionaryId', uuidV4());
+    json.set('dictionaryId', null);
 
     return this.store.createRecord('dictionary', {
       json: json

--- a/app/models/record.js
+++ b/app/models/record.js
@@ -3,7 +3,6 @@ import { alias } from '@ember/object/computed';
 import { getOwner } from '@ember/application';
 import EmberObject, { computed, getWithDefault } from '@ember/object';
 import { Copyable } from 'ember-copy';
-import uuidV4 from "uuid/v4";
 import Model from 'mdeditor/models/base';
 import {
   validator,
@@ -85,7 +84,7 @@ const Record = Model.extend(Validations, Copyable, {
         metadata: {
           metadataInfo: {
             metadataIdentifier: {
-              identifier: uuidV4(),
+              identifier: null,
               namespace: 'urn:uuid'
             },
             metadataContact: [],
@@ -250,7 +249,7 @@ const Record = Model.extend(Validations, Copyable, {
     json.set('metadata.resourceInfo.resourceType', getWithDefault(json,
       'metadata.resourceInfo.resourceType', [{}]));
     json.set('metadata.metadataInfo.metadataIdentifier', {
-      identifier: uuidV4(),
+      identifier: null,
       namespace: 'urn:uuid'
     });
 

--- a/app/pods/contact/new/id/route.js
+++ b/app/pods/contact/new/id/route.js
@@ -14,10 +14,14 @@ export default Route.extend({
     let record = this.store.peekRecord('contact', params.contact_id);
 
     if (record) {
+      record.set('contactId', params.contact_id);
       return record;
     }
 
-    return this.store.findRecord('contact', params.contact_id);
+    return this.store.findRecord('contact', params.contact_id).then((record) => {
+      record.set('contactId', params.contact_id);
+      return record;
+    });
   },
 
   /**

--- a/app/pods/dictionary/new/id/route.js
+++ b/app/pods/dictionary/new/id/route.js
@@ -7,10 +7,14 @@ export default Route.extend({
     let record = this.store.peekRecord('dictionary', params.dictionary_id);
 
     if (record) {
+      record.set('dictionaryId', params.dictionary_id);
       return record;
     }
 
-    return this.store.findRecord('dictionary', params.dictionary_id);
+    return this.store.findRecord('dictionary', params.dictionary_id).then((record) => {
+      record.set('dictionaryId', params.dictionary_id);
+      return record;
+    });
   },
 
   breadCrumb: null,

--- a/app/pods/record/new/id/route.js
+++ b/app/pods/record/new/id/route.js
@@ -6,10 +6,14 @@ export default Route.extend({
     let record = this.store.peekRecord('record', params.record_id);
 
     if(record) {
+      record.set('recordId', params.record_id)
       return record;
     }
 
-    return this.store.findRecord('record', params.record_id);
+    return this.store.findRecord('record', params.record_id).then((record) => {
+      record.set('recordId', params.record_id);
+      return record;
+    });
   },
 
   breadCrumb: null,


### PR DESCRIPTION
### Closing issues

closes #481 

## Pull Request

* **Please check if the PR fulfills these requirements**
  - [x] The commit message follows our guidelines
  - [x] Tests for the changes have been added (for bug fixes / features)
  ~~- [ ] Docs have been added / updated (for bug fixes / features)~~


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- In this PR we introduce the use of the Ember Internal Ids as the source of tracking the record in the `datastore` as well as using it to uniquely identify a `record`, `dictionary`, or `contact`


* **What is the current behavior?** (You can also link to an open issue here)
- Current state of the app has the use of a package called `UUID` that generates unique Ids for records, dictionaries, and contacts, which doesn't allow us to validate Ids.


* **What is the new behavior (if this is a feature change)?**
- This PR will not fix existing mdJson datasets that have existing long UUID,


