### PR TITLE
Configurable ScienceBase metadata publishing endpoint

### DIFF
--- a/lib/mdeditor-sciencebase/addon/components/sb-publisher.js
+++ b/lib/mdeditor-sciencebase/addon/components/sb-publisher.js
@@ -135,6 +135,7 @@ export default Component.extend({
     return TreeNode.create({
       _record: rec,
       config: this.get("config"),
+      settings: settings
     });
   },
 

--- a/lib/mdeditor-sciencebase/addon/templates/components/sb-settings.hbs
+++ b/lib/mdeditor-sciencebase/addon/templates/components/sb-settings.hbs
@@ -5,6 +5,12 @@
     placeholder="Enter the identifier for the default Parent item."
     change=save
   }}
+  {{input/md-input
+    label="Publishing Endpoint"
+    value=model.sb-publishEndpoint
+    placeholder="Enter the endpoint for a publishing service."
+    change=save
+  }}
   {{!-- {{input/md-input
     label="Default Community"
     value=model.sb-defaultCommunity

--- a/lib/mdeditor-sciencebase/addon/utils/config.js
+++ b/lib/mdeditor-sciencebase/addon/utils/config.js
@@ -4,7 +4,7 @@ export default {
   description:
     "ScienceBase is a collaborative scientific data and information management platform",
   icon: "globe",
-  rootURI: "https://sbmd-service.djcase.com/",
+  rootURI: "https://api.sciencebase.gov/sbmd-service/",
   rootItemURL: "https://www.sciencebase.gov/catalog/item/",
   defaultParent: "59ef8a34e4b0220bbd98d449",
   settingsComponent: "sb-settings",

--- a/lib/mdeditor-sciencebase/addon/utils/sb-tree-node.js
+++ b/lib/mdeditor-sciencebase/addon/utils/sb-tree-node.js
@@ -262,7 +262,12 @@ export default EmberObject.extend({
   publish(refreshToken) {
     let record = this;
     let sbId = record.get("sbId");
-    let rootURI = this.get("config.rootURI");
+    let publishOptions = record.get("settings");
+    let rootURI = getWithDefault(
+      publishOptions,
+      "sb-publishEndpoint",
+      this.get("config.rootURI")
+    );
     let defaultParent = this.get("config.defaultParent");
     let url =
       record.get("type") === "project"


### PR DESCRIPTION
### Closing issues

Closes https://github.com/adiwg/mdEditor/issues/708

## Pull Request

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

  * This adds a user-configurable url field in settings that allows you to specify the endpoint for publishing to ScienceBase.

* **What is the current behavior?** (You can also link to an open issue here)

  * Currently the API endpoint it hard-coded in the app.

* **What is the new behavior (if this is a feature change)?**

  * Going forward, users will be able to specify in the settings where they want to publish the metadata.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

  * No
