### PR TITLE
Fix custom schema import

### DIFF
--- a/app/models/custom-profile.js
+++ b/app/models/custom-profile.js
@@ -1,9 +1,8 @@
-import Model, { attr } from '@ember-data/model';
+import Model, { attr, hasMany } from '@ember-data/model';
 import { computed, observer } from '@ember/object';
 import { or, alias, notEmpty } from '@ember/object/computed';
 import { once } from '@ember/runloop';
 import { inject as service } from '@ember/service';
-import { checkVersion } from 'mdeditor/models/schema';
 import { validator, buildValidations } from 'ember-cp-validations';
 
 // [{
@@ -74,20 +73,14 @@ export default Model.extend(Validations, {
   definitions: service('profile'),
   uri: attr('string'),
   alias: attr('string'),
-  altDescription: attr('string'),
-  remoteVersion: attr('string'),
-  config: attr('json'),
+  title: attr('string'),
+  description: attr('string'),
   profileId: attr('string'),
 
-  title: or('alias', 'config.title'),
-  identifier: alias('config.identifier'),
-  namespace: alias('config.namespace'),
-  description: or('altDescription', 'config.description'),
-  localVersion: alias('config.version'),
-  components: alias('config.components'),
-  nav: alias('config.nav'),
-  hasUpdate: computed('localVersion', 'remoteVersion', checkVersion),
-
+  profileTitle: or('alias', 'title'),
+  identifier: alias('id').readOnly(),
+  components: alias('profile.components').readOnly(),
+  schemas: hasMany('schemas'),
   definition: computed('profileId', function () {
     return this.definitions.profiles.findBy('identifier', this.profileId);
   }),

--- a/app/models/custom-profile.js
+++ b/app/models/custom-profile.js
@@ -71,11 +71,13 @@ export default Model.extend(Validations, {
   },
 
   definitions: service('profile'),
+
   uri: attr('string'),
   alias: attr('string'),
   title: attr('string'),
   description: attr('string'),
   profileId: attr('string'),
+  thesauri: attr({ defaultValue: () => [] }),
 
   profileTitle: or('alias', 'title'),
   identifier: alias('id').readOnly(),
@@ -84,8 +86,6 @@ export default Model.extend(Validations, {
   definition: computed('profileId', function () {
     return this.definitions.profiles.findBy('identifier', this.profileId);
   }),
-
-  thesauri: alias('config.thesauri'),
 
   /* eslint-disable ember/no-observers */
   updateSettings: observer(

--- a/app/pods/import/route.js
+++ b/app/pods/import/route.js
@@ -68,6 +68,10 @@ export default Route.extend(ScrollTo, {
         return json.name || 'NO NAME';
       case 'schemas':
         return record.attributes.title || 'NO TITLE';
+      case 'custom-profiles':
+        return record.attributes.title || 'NO TITLE';
+      case 'profiles':
+        return record.attributes.alias || 'NO TITLE';
       default:
         return 'N/A';
     }
@@ -126,8 +130,7 @@ export default Route.extend(ScrollTo, {
       },
       attributes: computed(function () {
         return {
-          json: null, //,
-          //date-updated: '2017-05-18T21:21:34.446Z'
+          json: null,
         };
       }),
       type: null,
@@ -214,38 +217,6 @@ export default Route.extend(ScrollTo, {
 
     return this.mapRecords(map);
   },
-
-  // mapMdJSON(data) {
-  //   let map = A();
-
-  //   if (isArray(data.json)) {
-  //     data.json.forEach((item) => {
-  //       // Check for mdDictionary and set dictionaryId in dataDictionary
-  //       if (item.mdDictionary && item.dataDictionary) {
-  //         item.dataDictionary.forEach((dictionary, index) => {
-  //           if (!dictionary.dictionaryId && item.mdDictionary[index]) {
-  //             dictionary.dictionaryId = item.mdDictionary[index];
-  //           }
-  //         });
-  //       }
-  //       map = map.concat(this.formatMdJSON(item));
-  //     });
-  //   } else {
-  //     // Check for mdDictionary and set dictionaryId in dataDictionary
-  //     if (data.json.mdDictionary && data.json.dataDictionary) {
-  //       data.json.dataDictionary.forEach((dictionary, index) => {
-  //         if (!dictionary.dictionaryId && data.json.mdDictionary[index]) {
-  //           dictionary.dictionaryId = data.json.mdDictionary[index];
-  //         }
-  //       });
-  //     }
-  //     map = map.concat(this.formatMdJSON(data.json));
-  //   }
-
-  //   set(data, 'json.data', map);
-
-  //   return this.mapRecords(map);
-  // },
 
   mapRecords(records) {
     return records.reduce((map, item) => {

--- a/app/pods/settings/profile/index/controller.js
+++ b/app/pods/settings/profile/index/controller.js
@@ -33,25 +33,6 @@ export default Controller.extend({
     },
     saveProfile() {
       let profile = this.profile;
-
-      // Ensure title and description are properly stored
-      // If config doesn't exist yet, create it
-      if (!profile.get('config')) {
-        profile.set('config', {});
-      }
-
-      // Ensure title is stored in the appropriate backing property
-      if (profile.get('title') && !profile.get('alias')) {
-        // If title is set but alias is not, store it in config.title
-        profile.set('config.title', profile.get('title'));
-      }
-
-      // Ensure description is stored in the appropriate backing property
-      if (profile.get('description') && !profile.get('altDescription')) {
-        // If description is set but altDescription is not, store it in config.description
-        profile.set('config.description', profile.get('description'));
-      }
-
       return profile.save();
     },
 

--- a/app/services/custom-profile.js
+++ b/app/services/custom-profile.js
@@ -187,8 +187,12 @@ export default Service.extend({
 
   async createNewCustomProfile(profileConfig) {
     const newProfile = this.store.createRecord('custom-profile');
-    newProfile.set('config', profileConfig);
+    newProfile.set('uri', profileConfig.uri || null);
+    newProfile.set('alias', profileConfig.title || '');
+    newProfile.set('title', profileConfig.title);
+    newProfile.set('description', profileConfig.description || '');
     newProfile.set('profileId', profileConfig.identifier);
+    newProfile.set('thesauri', profileConfig.thesauri || []);
     await newProfile.save();
   },
 


### PR DESCRIPTION
Closes #734 
Closes #740 

# Description

This PR fixes the issues with profiles loaded via URL and profiles imported via the import page. This should resolve all issues with loading profiles in any way.

## Changes

- Reverting the custom-profile model back to what it was, except for the addition of thesauri which is now just a regular array.
- Fixed the import view so that it displays the title for profiles and custom-profiles
- Removed extra code that is no longer necessary from the profile page controller
- Added the logic to load and save a custom profile for the loadCustomProfilesFromUrl function so that it works correctly

**No breaking changes**

### Testing

Tested importing profiles from https://raw.githubusercontent.com/USFWS/ak-md-profiles/refs/heads/main/AKRegion-Profiles-mdeditor-20250310.json

Tested loading profiles from url from https://raw.githubusercontent.com/USGS-NGGDPP/mdEditor-profiles/refs/heads/main/manifest.json