### PR TITLE
Autosave support for PouchDB records

### DIFF
--- a/app/models/base.js
+++ b/app/models/base.js
@@ -57,15 +57,16 @@ const Base = Model.extend({
     }
   }),
 
-  observeAutoSave: observer('hasDirtyHash',
+  observeAutoSave: observer('hasDirtyAttributes', 'hasDirtyHash',
     function () {
       if(this.isNew || this.isEmpty) {
         return;
       }
 
-      if(this.get('settings.data.autoSave') && this.hasDirtyHash) {
-        once(this, async function () {
-          await this.save();
+      if(this.get('settings.data.autoSave') && (this.hasDirtyHash ||
+          this.hasDirtyAttributes)) {
+        once(this, function () {
+          this.save();
         });
       }
     }

--- a/app/models/base.js
+++ b/app/models/base.js
@@ -66,10 +66,10 @@ const Base = Model.extend({
       if(this.get('settings.data.autoSave') && this.hasDirtyHash) {
         once(this, async function () {
           await this.save();
-          await this.pouch.updatePouchRecord(this);
         });
       }
-    }),
+    }
+  ),
 
   applyPatch() {
     once(this, function () {
@@ -98,6 +98,9 @@ const Base = Model.extend({
 
     this.setCurrentHash(json);
     this.set('jsonSnapshot', json);
+
+    // Pouch handling
+    this.pouch.updatePouchRecord(this);
   },
 
   wasLoaded() {

--- a/app/pods/components/control/md-pouch-record-table/pouch-buttons/update/component.js
+++ b/app/pods/components/control/md-pouch-record-table/pouch-buttons/update/component.js
@@ -16,8 +16,8 @@ export default class MdPouchRecordPouchUpdateButtonComponent extends Component {
 
   @action
   async update() {
-    const { record, relatedRecord } = this.args;
-    await this.pouch.updatePouchRecord(record, relatedRecord);
+    const { record } = this.args;
+    await this.pouch.updatePouchRecord(record);
     this.updated = true;
   }
 }

--- a/app/pods/contact/show/route.js
+++ b/app/pods/contact/show/route.js
@@ -7,10 +7,7 @@ export default Route.extend(ScrollTo, {
   flashMessages: service(),
   pouch: service(),
 
-  async model(params) {
-    // Finding pouch-contact records needs to happen first
-    // to load them into the store as related contact records
-    await this.store.findAll('pouch-contact');
+  model(params) {
     return this.store.peekRecord('contact', params.contact_id);
   },
 

--- a/app/pods/contact/show/route.js
+++ b/app/pods/contact/show/route.js
@@ -18,7 +18,7 @@ export default Route.extend(ScrollTo, {
     saveContact: async function() {
       const model = this.currentRouteModel();
       await model.save();
-      await this.pouch.updatePouchRecord(model.pouchContact, model);
+      await this.pouch.updatePouchRecord(model);
       this.flashMessages.success(`Saved Contact: ${model.get('title')}`);
     },
 

--- a/app/pods/dictionary/show/edit/route.js
+++ b/app/pods/dictionary/show/edit/route.js
@@ -31,7 +31,7 @@ export default Route.extend(HashPoll, DoCancel, {
     saveDictionary: async function () {
       const model = this.currentRouteModel();
       await model.save();
-      await this.pouch.updatePouchRecord(model.pouchDictionary, model);
+      await this.pouch.updatePouchRecord(model);
       this.flashMessages.success(`Saved Dictionary: ${model.get('title')}`);
     },
     cancelDictionary: function () {

--- a/app/pods/dictionary/show/edit/route.js
+++ b/app/pods/dictionary/show/edit/route.js
@@ -31,7 +31,6 @@ export default Route.extend(HashPoll, DoCancel, {
     saveDictionary: async function () {
       const model = this.currentRouteModel();
       await model.save();
-      await this.pouch.updatePouchRecord(model);
       this.flashMessages.success(`Saved Dictionary: ${model.get('title')}`);
     },
     cancelDictionary: function () {

--- a/app/pods/dictionary/show/route.js
+++ b/app/pods/dictionary/show/route.js
@@ -5,10 +5,7 @@ import { copy } from 'ember-copy';
 export default Route.extend({
   flashMessages: service(),
 
-  async model(params) {
-    // Finding pouch-dictionary records needs to happen first
-    // to load them into the store as related dictionary records
-    await this.store.findAll('pouch-dictionary');
+  model(params) {
     return this.store.peekRecord('dictionary', params.dictionary_id);
   },
 

--- a/app/pods/export/route.js
+++ b/app/pods/export/route.js
@@ -125,6 +125,9 @@ export default Route.extend(ScrollTo, {
           item.attributes.json = JSON.stringify(jsonData);
         }
 
+        // Remove all PouchDB relationships
+        delete item.relationships;
+
         return item;
       });
 

--- a/app/pods/import/route.js
+++ b/app/pods/import/route.js
@@ -454,6 +454,13 @@ export default Route.extend(ScrollTo, {
           .rejectBy('type', 'settings'),
       };
 
+      // Remove all PouchDB relationships
+      data.data.forEach((record) => {
+        if (record.relationships) {
+          delete record.relationships;
+        }
+      });
+
       store
         .importData(data, {
           truncate: !this.currentRouteModel().get('merge'),

--- a/app/pods/record/show/edit/route.js
+++ b/app/pods/record/show/edit/route.js
@@ -36,7 +36,6 @@ export default Route.extend(HashPoll, DoCancel, {
     saveRecord: async function () {
       const model = this.currentRouteModel();
       await model.save();
-      await this.pouch.updatePouchRecord(model);
       this.flashMessages.success(`Saved Record: ${model.get('title')}`);
     },
 

--- a/app/pods/record/show/edit/route.js
+++ b/app/pods/record/show/edit/route.js
@@ -36,7 +36,7 @@ export default Route.extend(HashPoll, DoCancel, {
     saveRecord: async function () {
       const model = this.currentRouteModel();
       await model.save();
-      await this.pouch.updatePouchRecord(model.pouchRecord, model);
+      await this.pouch.updatePouchRecord(model);
       this.flashMessages.success(`Saved Record: ${model.get('title')}`);
     },
 

--- a/app/pods/record/show/route.js
+++ b/app/pods/record/show/route.js
@@ -12,10 +12,7 @@ export default Route.extend({
 
     this.set('breadCrumb', crumb);
   },
-  async model(params) {
-    // Finding pouch-record records needs to happen first
-    // to load them into the store as related record records
-    await this.store.findAll('pouch-record');
+  model(params) {
     return this.store.peekRecord('record', params.record_id);
   },
 

--- a/app/services/pouch.js
+++ b/app/services/pouch.js
@@ -135,14 +135,19 @@ export default class PouchService extends Service {
 
   async updatePouchRecord(relatedRecord) {
     let pouchRecord;
-    if (relatedRecord.pouchRecord) {
-      pouchRecord = relatedRecord.pouchRecord;
-    }
-    if (relatedRecord.pouchContact) {
-      pouchRecord = relatedRecord.pouchContact;
-    }
-    if (relatedRecord.pouchDictionary) {
-      pouchRecord = relatedRecord.pouchDictionary;
+    switch(relatedRecord.constructor.modelName) {
+      case POUCH_TYPES.RECORD:
+        await this.store.findAll('pouch-record');
+        pouchRecord = relatedRecord.pouchRecord;
+        break;
+      case POUCH_TYPES.CONTACT:
+        await this.store.findAll('pouch-contact');
+        pouchRecord = relatedRecord.pouchContact;
+        break;
+      case POUCH_TYPES.DICTIONARY:
+        await this.store.findAll('pouch-dictionary');
+        pouchRecord = relatedRecord.pouchDictionary;
+        break;
     }
     // Only update the pouch record if one exists
     if (!!pouchRecord) {

--- a/app/services/pouch.js
+++ b/app/services/pouch.js
@@ -133,9 +133,22 @@ export default class PouchService extends Service {
     }
   }
 
-  async updatePouchRecord(pouchRecord, relatedRecord) {
-    pouchRecord.json = relatedRecord.cleanJson;
-    return await pouchRecord.save();
+  async updatePouchRecord(relatedRecord) {
+    let pouchRecord;
+    if (relatedRecord.pouchRecord) {
+      pouchRecord = relatedRecord.pouchRecord;
+    }
+    if (relatedRecord.pouchContact) {
+      pouchRecord = relatedRecord.pouchContact;
+    }
+    if (relatedRecord.pouchDictionary) {
+      pouchRecord = relatedRecord.pouchDictionary;
+    }
+    // Only update the pouch record if one exists
+    if (!!pouchRecord) {
+      pouchRecord.json = relatedRecord.cleanJson;
+      return await pouchRecord.save();
+    }
   }
 
   async deletePouchRecord(pouchRecord) {

--- a/lib/mdeditor-sciencebase/addon/templates/publish/sciencebase.hbs
+++ b/lib/mdeditor-sciencebase/addon/templates/publish/sciencebase.hbs
@@ -4,7 +4,8 @@
 
 <div class="sb-publish-instructions">
   Publishing to ScienceBase requires a token. To obtain a token, go to the
-  <a href="https://sciencebase.usgs.gov/manager/">ScienceBase Manager</a>, copy your API token, and paste it below.
+  <a href="https://sciencebase.usgs.gov/manager/" target="_blank" class="md-fa-link external">ScienceBase Manager
+  </a>, copy your API token, and paste it below.
 </div>
 
 {{sb-publisher}}


### PR DESCRIPTION
# Autosave support for PouchDB records

Closes #711
Closes #723
Closes #742
Closes #745
Closes #750

## Test plan

This branched has been deployed to a test site here: https://mdeditor.djcase.com/dashboard

- #711:
  - Enable AutoSave
  - Find a record, contact, or dictionary that has a PouchDB record attached to it
  - Open that record, edit a field (like the title), and see that it saved on the record
  - Go to the CouchDB sync screen, and see that the field is updated on the PouchDB record
- #723:
  - Disable AutoSave
  - Open up your browser console
  - Edit a record, contact, or dictionary
  - Check the console, and see if there's an error
- #742:
  - Go to the 'Publish' tab, and select the ScienceBase service to publish
  - Obtain and enter your ScienceBase API token
  - Select a record from the list and publish it
  - Note that the timestamp for the item on the ScienceBase list changes
  - Go to the 'Sync' tab to view the PouchDB records
  - The 'Update' option should not show up for the record that was published
 - #745:
   - Go to the ScienceBase publish page
   - Clicking on the link to the ScienceBase Manager page should open it in a new browser tab 
- #750:
  - Export an mdEditor.json file
  - In a different browser instance import the mdEditor.json export file
  - Go to the Sync page
  - The option to add and bulk import the PouchDB records should show up

## Pull Request

- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
  - This adds support for the AutoSave functionality while fixing a manual save bug
  - Refactors the way that PouchDB related records are happening on the model level
  - Adds external link and styling for the ScienceBase Manager link
  - Adds import/export handling for PouchDB

- **What is the current behavior?** (You can also link to an open issue here)
  - AutoSave currently doesn't work with PouchDB records, and manual save logs an error
  - Publishing records to ScienceBase updates records without updating their PouchDB equivalents
  - Opening the ScienceBase Manager link navigates away from the editor
  - Exporting and then importing PouchDB records prevents them from being created

- **What is the new behavior (if this is a feature change)?**
  - AutoSave should work with PouchDB records now
  - Publishing records to ScienceBase should update the PouchDB related records
  - The ScienceBase Manager page should open in a new window
  - Export/Import should work with PouchDB records goes

- **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
  - No

- **Other information**:
  - This may also fix a similar issue in #744