### PR TITLE
Change the logic of `Raster Descrption` object

### DIFF
--- a/app/pods/components/input/md-input/template.hbs
+++ b/app/pods/components/input/md-input/template.hbs
@@ -1,43 +1,44 @@
-{{#if label}}
+{{#if this.label}}
   <label>
-    {{label}}
+    {{this.label}}
     {{!--<div class="pull-right"></div> --}}
   </label>
-  {{#if showInfoTip}}
-    {{control/md-infotip text=placeholder}}
+  {{#if this.showInfoTip}}
+    <Control::MdInfotip @text={{this.placeholder}} />
   {{/if}}
 {{/if}}
 <div class="md-input-input">
-  {{input
-    value=value
-    placeholder=placeholder
-    required=required
-    type=type
-    step=step
-    maxlength=maxlength
-    class=inputClass
-    disabled=disabled
-    change=change
-  }}
+  <Input
+    @value={{this.value}}
+    @placeholder={{this.placeholder}}
+    @required={{this.required}}
+    @type={{this.type}}
+    @step={{this.step}}
+    @maxlength={{this.maxlength}}
+    class={{this.inputClass}}
+    @disabled={{this.disabled}}
+    @readonly={{this.readonly}}
+    @change={{this.change}}
+  />
 
   <span class="md-input-error">
-    {{#if showErrorMessage}}
+    {{#if this.showErrorMessage}}
       <span class="md-error">
         {{fa-icon "exclamation-circle"}}
-        {{#ember-tooltip side="right" tooltipClass="ember-tooltip md-tooltip danger"}}
-            {{v-get model valuePath "message"}}
-        {{/ember-tooltip}}
+        <EmberTooltip @side="right" @tooltipClass="ember-tooltip md-tooltip danger">
+            {{v-get this.model this.valuePath "message"}}
+        </EmberTooltip>
       </span>
     {{/if}}
 
-    {{#if showWarningMessage}}
+    {{#if this.showWarningMessage}}
       <span class="md-warning">
         {{fa-icon "exclamation-triangle"}}
-        {{#ember-tooltip side="right" tooltipClass="ember-tooltip md-tooltip warning"}}
-        {{v-get model valuePath "warningMessage"}}
-        {{/ember-tooltip}}
+        <EmberTooltip @side="right" @tooltipClass="ember-tooltip md-tooltip warning">
+        {{v-get this.model this.valuePath "warningMessage"}}
+        </EmberTooltip>
       </span>
     {{/if}}
   </span>
 </div>
-{{yield}}
+{{yield}}{{yield}}

--- a/app/pods/components/input/md-textarea/template.hbs
+++ b/app/pods/components/input/md-textarea/template.hbs
@@ -14,18 +14,20 @@
 
 {{#liquid-if isExpanded enableGrowth=true}}
   <div class='md-input-input'>
-    {{textarea
-      value=value
-      placeholder=placeholder
-      required=required
-      maxlength=maxlength
-      autoresize=autoresize
-      rows=rows
-      max-rows=maxrows
-      max-width=maxwidth
-      max-height=maxheight
-      class=inputClass
-    }}
+    <Textarea
+      @value={{this.value}}
+      @placeholder={{this.placeholder}}
+      @required={{this.required}}
+      @maxlength={{this.maxlength}}
+      @autoresize={{this.autoresize}}
+      @rows={{this.rows}}
+      @max-rows={{this.maxrows}}
+      @max-width={{this.maxwidth}}
+      @max-height={{this.maxheight}}
+      class={{this.inputClass}}
+      @readonly={{this.readonly}}
+      @disabled={{this.readonly}}
+    />
     <span class='md-input-error'>
       {{#if showErrorMessage}}
         <span class='md-error'>

--- a/app/pods/components/object/md-raster/preview/component.js
+++ b/app/pods/components/object/md-raster/preview/component.js
@@ -3,7 +3,6 @@ import { alias } from '@ember/object/computed';
 import { Validations } from '../component';
 
 export default Component.extend(Validations, {
-
   /**
    * mdEditor class for input and edit of mdJSON 'coverageDescription' object.
    * The class manages the maintenance of an array of raster objects.
@@ -24,7 +23,7 @@ export default Component.extend(Validations, {
    * @requires alias
    * @default "alias('model.coverageName')"
    */
-  name: alias('model.coverageName'),
+  name: alias('item.coverageName'),
 
   /**
    * 'description' is the alias for 'coverageDescription' used in the validations for the
@@ -35,5 +34,5 @@ export default Component.extend(Validations, {
    * @requires alias
    * @default "alias('model.coverageDescription')"
    */
-  description: alias('model.coverageDescription')
+  description: alias('item.coverageDescription'),
 });

--- a/app/pods/components/object/md-raster/preview/template.hbs
+++ b/app/pods/components/object/md-raster/preview/template.hbs
@@ -6,7 +6,8 @@
       placeholder="The name(title) of the raster."
       profilePath=(concat profilePath ".coverageName")
       showValidations=true
-      value=model.coverageName
+      value=item.coverageName
+      readonly=true
     }}
   </div>
   <div class="form-group">
@@ -16,7 +17,8 @@
       placeholder="A description of the raster."
       profilePath=(concat profilePath ".coverageDescription")
       showValidations=true
-      value=model.coverageDescription
+      value=item.coverageDescription
+      readonly=true
     }}
   </div>
 </form>

--- a/app/pods/components/object/md-spatial-info/template.hbs
+++ b/app/pods/components/object/md-spatial-info/template.hbs
@@ -32,7 +32,6 @@
   {{object/md-spatial-resolution model=editing profilePath=(concat profilePath ".spatialResolution")}}
 {{/object/md-object-table}}
 
-
 {{object/md-objectroute-table
   attributes=" "
   items=model.coverageDescription
@@ -46,7 +45,9 @@
   profilePath=(concat profilePath ".coverageDescription")
   hideIndex=false
   condensed=false
-  editOnAdd=false
+  editOnAdd=true
+  routeParams=index
+  scrollToId=(concat "md-raster-" rasterId)
   data-spy="Raster Descriptions"
   addSubbar="md-subbar-extra"
 }}


### PR DESCRIPTION
The key issue is that in the `md-raster/preview/component.js`, was expecting the data to be available as `model.coverageName` and `model.coverageDescription`, but the data was being passed as `item.coverageName` and `item.coverageDescription`.

When the `md-object-table` renders the preview template, it passes the data as `item=item`, but the component is looking for model.

Also added a `editRoute` logic to bypass giving a `coverageName` or `coverageDescription` before editing the Raster

### Closing issues
closes #744 

## Pull Request

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix for Raster description not displaying the `name` or the `description` of the Raster


* **What is the current behavior?** (You can also link to an open issue here)
#744 


* **What is the new behavior (if this is a feature change)?**
- User will click 'Add Raster Description' and it will take them to the specific route for that indexed Raster


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
- No


* **Other information**:

https://github.com/user-attachments/assets/551f9cfa-8a1c-467e-a41d-0bb5a6e8a19b

