### PR TITLE
Feature: Refactor `mdTranslatorAPI URL` and `itisProxyUrl` to have no default, and added configuration validation 

### DIFF
--- a/app/mixins/object-template.js
+++ b/app/mixins/object-template.js
@@ -53,7 +53,6 @@ export default Mixin.create({
    * @return {Array}
    */
   applyTemplateArray(propertyName, defaults) {
-    console.log(propertyName);
     let property = this.get(propertyName);
     let Template = this.templateClass;
 

--- a/app/models/setting.js
+++ b/app/models/setting.js
@@ -2,14 +2,13 @@ import Model, { attr } from '@ember-data/model';
 import { alias } from '@ember/object/computed';
 import { run } from '@ember/runloop';
 import { inject as service } from '@ember/service';
-import EmberObject, { observer } from "@ember/object";
+import EmberObject, { observer } from '@ember/object';
 
 const defaultValues = {
-  mdTranslatorAPI: 'https://api.sciencebase.gov/mdTranslator/api/v3/translator',
-  itisProxyUrl: 'https://api.sciencebase.gov/mdTranslator',
+  // itisProxyUrl: 'https://api.sciencebase.gov/mdTranslator',
   // mdTranslatorAPI: 'https://dev-mdtranslator.mdeditor.org/api/v3/translator',
   // itisProxyUrl: 'https://dev-mdtranslator.mdeditor.org',
-  fiscalStartMonth: '10'
+  fiscalStartMonth: '10',
 };
 
 const theModel = Model.extend({
@@ -35,81 +34,71 @@ const theModel = Model.extend({
   },
   //cleaner: inject.service(),
   compressOnSave: attr('boolean', {
-    defaultValue: true
+    defaultValue: true,
   }),
   showSplash: attr('boolean', {
-    defaultValue: true
+    defaultValue: true,
   }),
   keepSettings: attr('boolean', {
-    defaultValue: true
+    defaultValue: true,
   }),
   autoSave: attr('boolean', {
-    defaultValue: false
+    defaultValue: false,
   }),
   showDelete: attr('boolean', {
-    defaultValue: false
+    defaultValue: false,
   }),
   showCopy: attr('boolean', {
-    defaultValue: false
+    defaultValue: false,
   }),
   lastVersion: attr('string', {
-    defaultValue: ''
+    defaultValue: '',
   }),
   dateUpdated: attr('date', {
     defaultValue() {
       return new Date();
-    }
+    },
   }),
   characterSet: attr('string', {
-    defaultValue: 'UTF-8'
+    defaultValue: 'UTF-8',
   }),
   country: attr('string', {
-    defaultValue: 'USA'
+    defaultValue: 'USA',
   }),
   language: attr('string', {
-    defaultValue: 'eng'
+    defaultValue: 'eng',
   }),
   importUriBase: attr('string', {
-    defaultValue: ''
+    defaultValue: '',
   }),
-  mdTranslatorAPI: attr('string', {
-    defaultValue: defaultValues.mdTranslatorAPI
-  }),
-  itisProxyUrl: attr('string', {
-    defaultValue: defaultValues.itisProxyUrl
-  }),
+  mdTranslatorAPI: attr('string'),
+  itisProxyUrl: attr('string'),
   fiscalStartMonth: attr('string', {
-    defaultValue: defaultValues.fiscalStartMonth
+    defaultValue: defaultValues.fiscalStartMonth,
   }),
   repositoryDefaults: attr('json'),
   publishOptions: attr('json', {
     defaultValue: function () {
       return EmberObject.create();
-    }
+    },
   }),
   customSchemas: attr('json', {
     defaultValue: function () {
       return [];
-    }
+    },
   }),
   locale: alias('defaultLocale'),
 
   wasLoaded() {
-    this.settings
-      .setup();
+    this.settings.setup();
   },
-  updateSettings: observer('hasDirtyAttributes',
-    function () {
-      if(this.hasDirtyAttributes) {
-        run.once(this, function () {
-          this.save();
-        });
-      }
-    })
+  updateSettings: observer('hasDirtyAttributes', function () {
+    if (this.hasDirtyAttributes) {
+      run.once(this, function () {
+        this.save();
+      });
+    }
+  }),
 });
 
-export {
-  defaultValues,
-  theModel as
-  default
-};
+export { defaultValues, theModel as default };

--- a/app/pods/components/control/md-modal/component.js
+++ b/app/pods/components/control/md-modal/component.js
@@ -82,6 +82,9 @@ export default Component.extend({
    * @method confirm
    */
   confirm() {
+    if (this.confirmAction) {
+      this.confirmAction();
+    }
     this.closeModal();
   },
 

--- a/app/pods/components/control/md-modal/template.hbs
+++ b/app/pods/components/control/md-modal/template.hbs
@@ -21,10 +21,10 @@
     </div>
     <div class="md-modal-buttons pull-right">
       {{#if showConfirm}}
-        <button type="button" class="btn btn-success" {{action "confirm"}}>{{confirmLabel}}</button>
+        <button type="button" class="btn btn-success" {{on "click" this.confirm}}>{{this.confirmLabel}}</button>
       {{/if}}
-      {{#if showCancel}}
-        <button type="button" class="btn btn-warning" {{action "cancel"}}>Cancel</button>
+      {{#if this.showCancel}}
+        <button type="button" class="btn btn-warning" {{on "click" this.cancel}}>Cancel</button>
       {{/if}}
     </div>
   {{/modal-dialog}}

--- a/app/pods/import/route.js
+++ b/app/pods/import/route.js
@@ -323,12 +323,31 @@ export default Route.extend(ScrollTo, {
     });
   },
 
+  checkApiConfiguration() {
+    // Check if mdTranslatorAPI is configured
+    if (
+      this.get('settings.data.mdTranslatorAPI') === null ||
+      this.get('settings.data.mdTranslatorAPI') === undefined ||
+      this.get('settings.data.mdTranslatorAPI') === ''
+    ) {
+      // Show modal to alert user
+      console.log('mdTranslator API is not configured');
+      this.controller.set('showApiModal', true);
+      return false;
+    }
+    return true;
+  },
+
   actions: {
     getColumns() {
       return this.columns;
     },
     getIcon(type) {
       return this.icons[type];
+    },
+    goToSettings() {
+      this.controller.set('showApiModal', false);
+      this.transitionTo('settings.main');
     },
     readData(file) {
       let json;
@@ -337,7 +356,17 @@ export default Route.extend(ScrollTo, {
       let cmp = this;
 
       new Promise((resolve, reject) => {
+        // Check API configuration first
+        if (!this.checkApiConfiguration()) {
+          reject(
+            'mdTranslator API URL is not configured. Please configure it in Settings.'
+          );
+          return;
+        }
+
+        // Then check file type specifics
         if (file.type.match(/.*\/xml$/)) {
+          // If it's XML, proceed with XML translation
           set(controller, 'isTranslating', true);
           this.flashMessages.info(`Translation service provided by ${url}.`);
 
@@ -380,6 +409,7 @@ export default Route.extend(ScrollTo, {
               }
             );
         } else {
+          // If it's not XML (i.e., it's JSON), process it directly
           try {
             json = JSON.parse(file.data);
           } catch (e) {
@@ -410,6 +440,14 @@ export default Route.extend(ScrollTo, {
       let uri = this.controller.get('importUri');
       let controller = this.controller;
       let route = this;
+
+      // Check API configuration first
+      if (!this.checkApiConfiguration()) {
+        this.flashMessages.danger(
+          'mdTranslator API URL is not configured. Please configure it in Settings.'
+        );
+        return;
+      }
 
       set(controller, 'isLoading', true);
 

--- a/app/pods/import/template.hbs
+++ b/app/pods/import/template.hbs
@@ -136,3 +136,20 @@
 
 </div>
 {{outlet}}
+
+{{#control/md-modal
+  isShowing=showApiModal
+  showConfirm=true
+  confirmLabel="Go to Settings"
+  showCancel=true
+  confirm=(route-action "goToSettings")
+  cancel=(action (mut showApiModal) false)
+}}
+  <div class='alert alert-info' role='alert'>{{fa-icon 'exclamation-triangle'}}
+    mdTranslator API URL required.
+  </div>
+  <p>
+    Please go to <LinkTo @route='settings'>Settings > Main</LinkTo> and configure the
+    mdTranslator API URL before importing.
+  </p>
+{{/control/md-modal}}

--- a/app/pods/record/show/edit/taxonomy/collection/index/route.js
+++ b/app/pods/record/show/edit/taxonomy/collection/index/route.js
@@ -1,38 +1,62 @@
 import Route from '@ember/routing/route';
 import { get } from '@ember/object';
 import ScrollTo from 'mdeditor/mixins/scroll-to';
-
+import { inject as service } from '@ember/service';
 
 export default Route.extend(ScrollTo, {
-  setupController: function() {
+  settings: service(),
+
+  setupController: function () {
     // Call _super for default behavior
     this._super(...arguments);
 
-    this.controller.set('parentModel', this.modelFor(
-      'record.show.edit'));
-    this.controller.set('collectionId', get(this.controllerFor(
-        'record.show.edit.taxonomy.collection'),
-      'collectionId'));
+    this.controller.set('parentModel', this.modelFor('record.show.edit'));
+    this.controller.set(
+      'collectionId',
+      get(
+        this.controllerFor('record.show.edit.taxonomy.collection'),
+        'collectionId'
+      )
+    );
   },
+
   actions: {
-    toList(){
+    toList() {
       this.transitionTo('record.show.edit.taxonomy');
     },
-    addTaxa(){
+
+    addTaxa() {
       this.controller.model.taxonomicClassification.pushObject({
-        _edit: true
+        _edit: true,
       });
     },
-    addITIS(){
+
+    addITIS() {
+      // Check if itisProxyUrl is configured
+      if (!this.get('settings.data.itisProxyUrl')) {
+        // Show modal to alert user
+        this.controller.set('showItisModal', true);
+        return;
+      }
+
+      // If itisProxyUrl is configured, proceed to ITIS page
       this.transitionTo('record.show.edit.taxonomy.collection.itis');
     },
+
+    goToSettings() {
+      this.controller.set('showItisModal', false);
+      this.transitionTo('settings.main');
+    },
+
     editSystem(index) {
-      this.transitionTo('record.show.edit.taxonomy.collection.system',
-          index)
-        .then(
-          function () {
-            this.setScrollTo('system');
-          }.bind(this));
-    }
-  }
+      this.transitionTo(
+        'record.show.edit.taxonomy.collection.system',
+        index
+      ).then(
+        function () {
+          this.setScrollTo('system');
+        }.bind(this)
+      );
+    },
+  },
 });

--- a/app/pods/record/show/edit/taxonomy/collection/index/template.hbs
+++ b/app/pods/record/show/edit/taxonomy/collection/index/template.hbs
@@ -40,3 +40,22 @@
 
 {{to-elsewhere named="md-scroll-spy-record-edit"
   send=(component "control/md-scroll-spy"  scrollInit=scrollTo setScrollTo=(route-action "setScrollTo"))}}
+
+
+{{#control/md-modal
+  isShowing=showItisModal
+  showConfirm=true
+  confirmLabel="Go to Settings"
+  showCancel=true
+  confirm=(route-action "goToSettings")
+  cancel=(action (mut showItisModal) false)
+
+}}
+<div class='alert alert-info' role='alert'>{{fa-icon 'exclamation-triangle'}}
+    ITIS Proxy URL is required.
+  </div>
+  <p>
+    Please go to <LinkTo @route='settings'>Settings > Main</LinkTo> and configure the
+    ITIS Proxy URL to add taxonomy from ITIS.
+  </p>
+{{/control/md-modal}}

--- a/app/pods/settings/main/template.hbs
+++ b/app/pods/settings/main/template.hbs
@@ -138,16 +138,25 @@ shadow=true
   </div>
   <hr class="col-md-12">
   <div class="col-md-8">
-    <label>mdTranslator API URL</label>
-    <div class="input-group">
-      {{input/md-input
+    {{input/md-input
+      label="mdTranslator API URL"
       type="url"
       value=model.mdTranslatorAPI
       placeholder="URL for the ADIwg Metadata Translator."
+    }}
+  </div>
+   <hr class="col-md-12">
+   <div class="col-md-8">
+    <label>Itis Proxy URL</label>
+    <div class="input-group">
+      {{input/md-input
+      type="url"
+      value=model.itisProxyUrl
+      placeholder="URL for the ITIS Proxy."
       }}
       <span class="input-group-btn">
-        <button class="btn btn-warning" type="button" {{action "resetMdTranslatorAPI" }}>Default
-          {{ember-tooltip tooltipClass="ember-tooltip md-tooltip info" text="Reset to default"}}
+        <button class="btn btn-info" type="button" {{action "deriveItisProxyUrl"}}>Derive from API URL
+          {{ember-tooltip tooltipClass="ember-tooltip md-tooltip info" text="Derive ITIS Proxy URL from mdTranslator API URL"}}
         </button>
       </span>
     </div>

--- a/app/pods/settings/route.js
+++ b/app/pods/settings/route.js
@@ -23,19 +23,23 @@ export default class SettingsRoute extends Route {
   setupController(controller, model) {
     super.setupController(controller, model);
 
-    const links = [{
-      title: 'Main',
-      target: 'settings.main',
-      tip: 'Main application settings'
-    }, {
-      title: 'Profiles',
-      target: 'settings.profile',
-      tip: 'Custom profile settings'
-    }, {
-      title: 'Validation',
-      target: 'settings.validation',
-      tip: 'Custom validation settings'
-    }]
+    const links = [
+      {
+        title: 'Main',
+        target: 'settings.main',
+        tip: 'Main application settings',
+      },
+      {
+        title: 'Profiles',
+        target: 'settings.profile',
+        tip: 'Custom profile settings',
+      },
+      {
+        title: 'Validation',
+        target: 'settings.validation',
+        tip: 'Custom validation settings',
+      },
+    ];
     controller.set('links', links);
   }
 
@@ -46,9 +50,10 @@ export default class SettingsRoute extends Route {
     window.localStorage.clear();
 
     if (this.settings.data.keepSettings) {
-
-      window.localStorage.setItem('index-settings',
-        `["settings-${data.data.id}"]`);
+      window.localStorage.setItem(
+        'index-settings',
+        `["settings-${data.data.id}"]`
+      );
       this.store.pushPayload('setting', data);
 
       let rec = this.store.peekRecord('setting', data.data.id);
@@ -70,10 +75,17 @@ export default class SettingsRoute extends Route {
   }
 
   @action
-  resetMdTranslatorAPI() {
-    let url = get(Setting, 'attributes').get('mdTranslatorAPI').options.defaultValue;
+  deriveItisProxyUrl() {
     let model = this.modelFor('settings.main');
+    const mdTranslatorAPI = model.get('mdTranslatorAPI');
 
-    model.set('mdTranslatorAPI', url);
+    if (mdTranslatorAPI) {
+      // Extract the base URL by removing the API path
+      // This will convert https://api.sciencebase.gov/mdTranslator/api/v3/translator
+      // to https://api.sciencebase.gov/mdTranslator
+      const baseUrl = mdTranslatorAPI.replace(/\/api\/v\d+\/translator$/, '');
+
+      model.set('itisProxyUrl', baseUrl);
+    }
   }
 }

--- a/app/services/settings.js
+++ b/app/services/settings.js
@@ -5,10 +5,8 @@ import { defaultValues } from 'mdeditor/models/setting';
 import { isEmpty } from '@ember/utils';
 
 const {
-  APP: {
-    version
-  },
-  environment
+  APP: { version },
+  environment,
 } = config;
 
 export default Service.extend({
@@ -25,40 +23,32 @@ export default Service.extend({
     let settings;
     let store = this.store;
 
-    store
-      .findAll('setting')
-      .then(function (s) {
-        let rec = s.get('firstObject');
+    store.findAll('setting').then(function (s) {
+      let rec = s.get('firstObject');
 
-        settings = rec ? rec : store.createRecord('setting');
+      settings = rec ? rec : store.createRecord('setting');
 
-        if(settings.get('lastVersion') !== version) {
-          settings.set('showSplash', environment !== 'test');
-          settings.set('lastVersion', version);
-        }
+      if (settings.get('lastVersion') !== version) {
+        settings.set('showSplash', environment !== 'test');
+        settings.set('lastVersion', version);
+      }
 
-        set(settings, 'repositoryDefaults', getWithDefault(settings,
-          'repositoryDefaults', []));
+      set(
+        settings,
+        'repositoryDefaults',
+        getWithDefault(settings, 'repositoryDefaults', [])
+      );
 
-        //update mdTranslatorAPI if default is being used
-        let isDefaultAPI = isEmpty(settings.get('mdTranslatorAPI')) || settings.get('mdTranslatorAPI').match(
-          'https://mdtranslator.herokuapp.com/api/v(.)/translator');
+      settings.notifyPropertyChange('hasDirtyAttributes');
 
-        if(isDefaultAPI) {
-          settings.set('mdTranslatorAPI', defaultValues.mdTranslatorAPI);
-        }
-
-        settings.notifyPropertyChange('hasDirtyAttributes');
-
-        if(!(me.get('isDestroyed') || me.get('isDestroying'))) {
-          me.set('data', settings);
-        }
-
-      });
+      if (!(me.get('isDestroyed') || me.get('isDestroying'))) {
+        me.set('data', settings);
+      }
+    });
   },
   repositoryTemplate: EmberObject.extend({
     init() {
       this._super(...arguments);
-    }
-  })
+    },
+  }),
 });

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -61,11 +61,11 @@
   <Layout::MdFooter @class='hidden-print' />
 </div>
 <EmberLoadRemover />
-
 <Control::MdModal
-  @isShowing={{settings.data.showSplash}}
+  @isShowing={{this.settings.data.showSplash}}
   @showConfirm={{true}}
   @confirmLabel='OK'
+  @confirm={{action (mut this.settings.data.showSplash) false}}
 >
   <div class='alert alert-info' role='alert'>{{fa-icon 'exclamation-triangle'}}
     Update Alert</div>
@@ -76,7 +76,7 @@
     <LinkTo @route='settings'>Settings</LinkTo>) when reporting bugs or issues.
     If you are having problems, you might want to
     <LinkTo @route='settings'> clear your localstorage.</LinkTo>
-    <strong style='color: red;'>CAUTION: Clearing your localstorage will delete
+    <strong class="text-danger">CAUTION: Clearing your localstorage will delete
       all records.</strong>
   </p>
   <p>
@@ -84,7 +84,6 @@
     <span class='text-info'><Control::MdRepoLink /></span>
   </p>
 </Control::MdModal>
-
 {{#if spotlight.show}}
   <Control::MdSpotlight />
 {{/if}}


### PR DESCRIPTION
## Overview
This PR adds validation checks for external service URLs before attempting to use them. Specifically, it adds modal alerts when users try to use features that require the `mdTranslator` API or ITIS Proxy URL without having these services configured in settings.

## Changes
1. XML Import Validation

- Added a check in the import route to verify if  `mdTranslatorAPI` is configured before attempting to translate XML and JSON files

- If the API URL is not configured, a modal is shown to the user explaining the issue

- The modal provides options to either go to settings to configure the API or cancel the operation

2. ITIS Taxonomy Integration

- Added a similar check in the taxonomy collection route to verify if `itisProxyUrl` is configured before attempting to add taxa from ITIS

- If the ITIS Proxy URL is not configured, a modal is shown to the user explaining the issue

- The modal provides the same options to configure the URL or cancel

3. Modal Component Enhancements

- Updated the md-modal component to better handle action passing

- Ensured compatibility with existing usages of the modal component throughout the application

- Added support for direct action handling in the modal buttons

### Closing issues
closes #725
closes #762 
closes #737 
closes #736

## Pull Request

* **Please check if the PR fulfills these requirements**
  - [x] The commit message follows our guidelines
  - [x] Tests for the changes have been added (for bug fixes / features)
  ~~- [ ] Docs have been added / updated (for bug fixes / features)~~


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature

* **What is the current behavior?** (You can also link to an open issue here)
#725 
#762
#738 
#737 
#736
Previously, when users attempted to use features requiring external services without having them configured, they would encounter confusing errors or the application would silently fail. These changes provide clear feedback to users about what's missing and guide them directly to where they can configure the necessary settings.

* **What is the new behavior (if this is a feature change)?**
This PR adds validation checks for external service URLs before attempting to use them. Specifically, it adds modal alerts when users try to use features that require the `mdTranslator` API or ITIS Proxy URL without having these services configured in settings.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
If the user has a current `mdTranslatorAPI` endpoint their won't be any changes to that field other than, there is no more `defaultAPI` hard-coded to the application.  However they will have to provide a `itisProxyUrl` if they are using any taxonomy in the records.  


* **Other information**:

https://github.com/user-attachments/assets/d39a0d78-6cdd-435f-a168-b9948d91e40f


https://github.com/user-attachments/assets/2cdd71fc-d882-41a8-ba08-02f4dd805720

