### PR TITLE
Refactor ScienceBase user setting to support publish options

### DIFF
--- a/app/instance-initializers/settings-couchdb.js
+++ b/app/instance-initializers/settings-couchdb.js
@@ -1,0 +1,10 @@
+import config from '../utils/couchdb-config';
+
+export function initialize(instance) {
+  let service = instance.lookup('service:publish');
+  service.get('catalogs').pushObject(config);
+}
+
+export default {
+  initialize
+};

--- a/app/models/setting.js
+++ b/app/models/setting.js
@@ -79,7 +79,7 @@ const theModel = Model.extend({
   repositoryDefaults: attr('json'),
   publishOptions: attr('json', {
     defaultValue: function () {
-      return EmberObject.create();
+      return [];
     },
   }),
   customSchemas: attr('json', {

--- a/app/models/setting.js
+++ b/app/models/setting.js
@@ -9,6 +9,19 @@ const defaultValues = {
   // mdTranslatorAPI: 'https://dev-mdtranslator.mdeditor.org/api/v3/translator',
   // itisProxyUrl: 'https://dev-mdtranslator.mdeditor.org',
   fiscalStartMonth: '10',
+  publishOptions: [
+    {
+      publisher: 'ScienceBase',
+      publisherEndpoint: '',
+      'sb-defaultParent': '',
+    },
+    {
+      publisher: 'CouchDB',
+      publisherEndpoint: '',
+      'couchdb-database': '',
+      'couchdb-username': '',
+    },
+  ],
 };
 
 const theModel = Model.extend({
@@ -79,7 +92,7 @@ const theModel = Model.extend({
   repositoryDefaults: attr('json'),
   publishOptions: attr('json', {
     defaultValue: function () {
-      return [];
+      return defaultValues.publishOptions.slice(); // Return a copy of the default array
     },
   }),
   customSchemas: attr('json', {

--- a/app/pods/components/control/md-couch-login/component.js
+++ b/app/pods/components/control/md-couch-login/component.js
@@ -26,12 +26,19 @@ export default class CouchLoginComponent extends Component {
   loadDefaults() {
     if (this.settings.data && !this.couch.loggedIn) {
       const publishOptions = this.settings.data.publishOptions || [];
-      const couchdbSettings = publishOptions.find(option => option.catalog === 'CouchDB');
-      
+      // Support both legacy 'catalog' field and new 'publisher' field
+      const couchdbSettings = publishOptions.find(
+        (option) =>
+          option.catalog === 'CouchDB' || option.publisher === 'CouchDB'
+      );
+
       if (couchdbSettings) {
         // Only set defaults if fields are empty to avoid overwriting user input
         if (!this.remoteUrl) {
-          this.remoteUrl = couchdbSettings['couchdb-url'] || null;
+          this.remoteUrl =
+            couchdbSettings.publisherEndpoint ||
+            couchdbSettings['couchdb-url'] ||
+            null;
         }
         if (!this.remoteName) {
           this.remoteName = couchdbSettings['couchdb-database'] || null;
@@ -46,19 +53,24 @@ export default class CouchLoginComponent extends Component {
   get settingsAvailable() {
     // Non-reactive getter to check if settings are loaded
     const hasSettings = !!this.settings.data;
-    
+
     // Schedule defaults loading for next run loop to avoid revalidation
     if (hasSettings && !this.couch.loggedIn && !this._defaultsScheduled) {
       this._defaultsScheduled = true;
       scheduleOnce('afterRender', this, 'loadDefaults');
     }
-    
+
     return hasSettings;
   }
 
   @action
   login() {
-    this.couch.login(this.remoteUrl, this.remoteName, this.username, this.password);
+    this.couch.login(
+      this.remoteUrl,
+      this.remoteName,
+      this.username,
+      this.password
+    );
     this.username = null;
     this.password = null;
     this.remoteUrl = null;

--- a/app/pods/components/couchdb-settings/component.js
+++ b/app/pods/components/couchdb-settings/component.js
@@ -1,0 +1,21 @@
+import Component from '@glimmer/component';
+import { set } from '@ember/object';
+
+export default class CouchdbSettingsComponent extends Component {
+  constructor() {
+    super(...arguments);
+    
+    // Ensure the model has the required properties
+    if (this.args.model) {
+      if (!this.args.model['couchdb-url']) {
+        set(this.args.model, 'couchdb-url', '');
+      }
+      if (!this.args.model['couchdb-database']) {
+        set(this.args.model, 'couchdb-database', '');
+      }
+      if (!this.args.model['couchdb-username']) {
+        set(this.args.model, 'couchdb-username', '');
+      }
+    }
+  }
+}

--- a/app/pods/components/couchdb-settings/template.hbs
+++ b/app/pods/components/couchdb-settings/template.hbs
@@ -1,7 +1,7 @@
 <div class="form">
   {{input/md-input
-    label="CouchDB URL"
-    value=(get @model "couchdb-url")
+    label="Publisher Endpoint"
+    value=@model.publisherEndpoint
     placeholder="Enter the CouchDB server URL (e.g., https://mycouch.example.com)"
     change=@save
   }}

--- a/app/pods/components/couchdb-settings/template.hbs
+++ b/app/pods/components/couchdb-settings/template.hbs
@@ -1,0 +1,23 @@
+<div class="form">
+  {{input/md-input
+    label="CouchDB URL"
+    value=(get @model "couchdb-url")
+    placeholder="Enter the CouchDB server URL (e.g., https://mycouch.example.com)"
+    change=@save
+  }}
+  {{input/md-input
+    label="CouchDB Database Name"
+    value=(get @model "couchdb-database")
+    placeholder="Enter the default database name"
+    change=@save
+  }}
+  {{input/md-input
+    label="Default Username"
+    value=(get @model "couchdb-username")
+    placeholder="Enter the default username (password will not be saved)"
+    change=@save
+  }}
+  <div class="alert alert-info">
+    <strong>Note:</strong> Passwords are not saved in settings for security reasons. You will need to enter your password each time you connect.
+  </div>
+</div>

--- a/app/pods/export/route.js
+++ b/app/pods/export/route.js
@@ -125,6 +125,47 @@ export default Route.extend(ScrollTo, {
           item.attributes.json = JSON.stringify(jsonData);
         }
 
+        // Handle settings migration from 'catalog' to 'publisher' in publishOptions
+        if (item.type === 'settings' && item.attributes?.publishOptions) {
+          let publishOptions = item.attributes.publishOptions;
+
+          // Migrate legacy 'catalog' field to new 'publisher' field for each publish option
+          publishOptions = publishOptions.map((option) => {
+            if (option.catalog && !option.publisher) {
+              option.publisher = option.catalog;
+              delete option.catalog;
+            }
+
+            // Migrate legacy endpoint fields to publisherEndpoint
+            if (!option.publisherEndpoint) {
+              if (option['sb-publishEndpoint']) {
+                option.publisherEndpoint = option['sb-publishEndpoint'];
+                delete option['sb-publishEndpoint'];
+              } else if (option['couchdb-url']) {
+                option.publisherEndpoint = option['couchdb-url'];
+                delete option['couchdb-url'];
+              } else {
+                option.publisherEndpoint =
+                  option.publisher === 'ScienceBase'
+                    ? 'https://api.sciencebase.gov/sbmd-service/'
+                    : '';
+              }
+            } else {
+              // Remove old fields even if publisherEndpoint exists
+              if (option['sb-publishEndpoint']) {
+                delete option['sb-publishEndpoint'];
+              }
+              if (option['couchdb-url']) {
+                delete option['couchdb-url'];
+              }
+            }
+
+            return option;
+          });
+
+          item.attributes.publishOptions = publishOptions;
+        }
+
         // Remove all PouchDB relationships
         delete item.relationships;
 

--- a/app/pods/publish/couchdb/route.js
+++ b/app/pods/publish/couchdb/route.js
@@ -1,0 +1,12 @@
+import Route from '@ember/routing/route';
+import config from '../../../utils/couchdb-config';
+
+export default class PublishCouchdbRoute extends Route {
+  breadCrumb = {
+    title: 'CouchDB'
+  };
+
+  model() {
+    return config;
+  }
+}

--- a/app/pods/publish/couchdb/template.hbs
+++ b/app/pods/publish/couchdb/template.hbs
@@ -1,0 +1,36 @@
+<div class="page-header text-info">
+  <h3>{{@model.name}} <small>Sync records with CouchDB</small></h3>
+</div>
+
+<div class="couchdb-publish-instructions">
+  <div class="alert alert-info">
+    <h4><span class="fa fa-info-circle"></span> About CouchDB Sync</h4>
+    <p>
+      CouchDB uses a sync mechanism rather than traditional publishing. 
+      You can synchronize your mdEditor records with a CouchDB database 
+      to share data across devices or with team members.
+    </p>
+  </div>
+
+  <div class="panel panel-default">
+    <div class="panel-heading">
+      <h4 class="panel-title">How to sync with CouchDB:</h4>
+    </div>
+    <div class="panel-body">
+      <ol>
+        <li><strong>Configure default settings</strong>: Set up your CouchDB connection defaults in 
+          <LinkTo @route="settings.main">Settings → Publishing Settings → CouchDB</LinkTo>
+        </li>
+        <li><strong>Go to the Sync page</strong>: Navigate to the Sync section to manage your CouchDB connections</li>
+        <li><strong>Login and sync</strong>: Connect to your CouchDB instance and synchronize your records</li>
+      </ol>
+    </div>
+  </div>
+
+  <div class="text-center" style="margin-top: 20px;">
+    <LinkTo @route="sync.list" class="btn btn-lg btn-primary">
+      <span class="fa fa-database"></span>
+      Go to Sync
+    </LinkTo>
+  </div>
+</div>

--- a/app/pods/settings/main/template.hbs
+++ b/app/pods/settings/main/template.hbs
@@ -218,7 +218,7 @@ collapsed=false
 shadow=false
 class="md-embedded"
 }}
-{{component catalog.settingsComponent model=model.publishOptions save=(route-action "save")}}
+{{component catalog.settingsComponent model=(compute (route-action "getPublishOptions") catalog.name) save=(route-action "save")}}
 {{/layout/md-card}}
 {{/each}}
 {{/layout/md-card}}

--- a/app/pods/settings/route.js
+++ b/app/pods/settings/route.js
@@ -78,7 +78,7 @@ export default class SettingsRoute extends Route {
   deriveItisProxyUrl() {
     let model = this.modelFor('settings.main');
     const mdTranslatorAPI = model.get('mdTranslatorAPI');
-
+    console.log(mdTranslatorAPI);
     if (mdTranslatorAPI) {
       // Extract the base URL by removing the API path
       // This will convert https://api.sciencebase.gov/mdTranslator/api/v3/translator
@@ -93,14 +93,22 @@ export default class SettingsRoute extends Route {
   getPublishOptions(catalogName) {
     let model = this.modelFor('settings.main');
     let publishOptions = model.get('publishOptions') || [];
-    
+
+    // Ensure publishOptions is always an array
+    if (!Array.isArray(publishOptions)) {
+      publishOptions = [];
+      model.set('publishOptions', publishOptions);
+    }
+
     // Find existing settings for this catalog
-    let catalogSettings = publishOptions.find(options => options.catalog === catalogName);
-    
+    let catalogSettings = publishOptions.find(
+      (options) => options.catalog === catalogName
+    );
+
     // If no settings exist for this catalog, create a default entry
     if (!catalogSettings) {
       catalogSettings = { catalog: catalogName };
-      
+
       // Initialize default properties based on catalog type
       if (catalogName === 'CouchDB') {
         catalogSettings['couchdb-url'] = '';
@@ -110,11 +118,11 @@ export default class SettingsRoute extends Route {
         catalogSettings['sb-defaultParent'] = '';
         catalogSettings['sb-publishEndpoint'] = '';
       }
-      
+
       publishOptions.pushObject(catalogSettings);
       model.set('publishOptions', publishOptions);
     }
-    
+
     return catalogSettings;
   }
 }

--- a/app/pods/settings/route.js
+++ b/app/pods/settings/route.js
@@ -88,4 +88,33 @@ export default class SettingsRoute extends Route {
       model.set('itisProxyUrl', baseUrl);
     }
   }
+
+  @action
+  getPublishOptions(catalogName) {
+    let model = this.modelFor('settings.main');
+    let publishOptions = model.get('publishOptions') || [];
+    
+    // Find existing settings for this catalog
+    let catalogSettings = publishOptions.find(options => options.catalog === catalogName);
+    
+    // If no settings exist for this catalog, create a default entry
+    if (!catalogSettings) {
+      catalogSettings = { catalog: catalogName };
+      
+      // Initialize default properties based on catalog type
+      if (catalogName === 'CouchDB') {
+        catalogSettings['couchdb-url'] = '';
+        catalogSettings['couchdb-database'] = '';
+        catalogSettings['couchdb-username'] = '';
+      } else if (catalogName === 'ScienceBase') {
+        catalogSettings['sb-defaultParent'] = '';
+        catalogSettings['sb-publishEndpoint'] = '';
+      }
+      
+      publishOptions.pushObject(catalogSettings);
+      model.set('publishOptions', publishOptions);
+    }
+    
+    return catalogSettings;
+  }
 }

--- a/app/router.js
+++ b/app/router.js
@@ -12,7 +12,8 @@ Router.map(function () {
   this.route('import');
   this.route('translate');
   this.route('publish', function () {
-    this.route('sciencebase')
+    this.route('sciencebase');
+    this.route('couchdb');
   });
   this.route('sync', function () {
     this.route('list');

--- a/app/utils/couchdb-config.js
+++ b/app/utils/couchdb-config.js
@@ -1,0 +1,7 @@
+export default {
+  name: 'CouchDB',
+  route: 'couchdb',
+  description: 'CouchDB is a document-oriented NoSQL database for data synchronization',
+  icon: 'database',
+  settingsComponent: 'couchdb-settings',
+};

--- a/lib/mdeditor-sciencebase/addon/components/sb-publisher.js
+++ b/lib/mdeditor-sciencebase/addon/components/sb-publisher.js
@@ -19,7 +19,8 @@ export default Component.extend({
 
   init() {
     this._super(...arguments);
-    let settings = this.get("settings.data.publishOptions");
+    let publishOptions = this.get("settings.data.publishOptions") || [];
+    let settings = publishOptions.find(option => option.catalog === 'ScienceBase') || {};
     let config = this.get("config");
     this.set(
       "treeRoot",
@@ -122,7 +123,8 @@ export default Component.extend({
 
   createNode(rec) {
     let config = this.get("config");
-    let settings = this.get("settings.data.publishOptions");
+    let publishOptions = this.get("settings.data.publishOptions") || [];
+    let settings = publishOptions.find(option => option.catalog === 'ScienceBase') || {};
     setProperties(config, {
       defaultParent: getWithDefault(
         settings,

--- a/lib/mdeditor-sciencebase/addon/components/sb-publisher.js
+++ b/lib/mdeditor-sciencebase/addon/components/sb-publisher.js
@@ -1,32 +1,37 @@
-import { alias, bool } from "@ember/object/computed";
-import Component from "@ember/component";
-import { isEmpty } from "@ember/utils";
-import { A } from "@ember/array";
-import { inject as service } from "@ember/service";
-import layout from "../templates/components/sb-publisher";
-import TreeNode from "../utils/sb-tree-node";
+import { alias, bool } from '@ember/object/computed';
+import Component from '@ember/component';
+import { isEmpty } from '@ember/utils';
+import { A } from '@ember/array';
+import { inject as service } from '@ember/service';
+import layout from '../templates/components/sb-publisher';
+import TreeNode from '../utils/sb-tree-node';
 import EmberObject, {
   set,
   setProperties,
   getWithDefault,
   get,
   computed,
-} from "@ember/object";
-import { allSettled } from "rsvp";
+} from '@ember/object';
+import { allSettled } from 'rsvp';
 
 export default Component.extend({
   layout,
 
   init() {
     this._super(...arguments);
-    let publishOptions = this.get("settings.data.publishOptions") || [];
-    let settings = publishOptions.find(option => option.catalog === 'ScienceBase') || {};
-    let config = this.get("config");
+    let publishOptions = this.get('settings.data.publishOptions') || [];
+    // Support both legacy 'catalog' field and new 'publisher' field
+    let settings =
+      publishOptions.find(
+        (option) =>
+          option.catalog === 'ScienceBase' || option.publisher === 'ScienceBase'
+      ) || {};
+    let config = this.get('config');
     this.set(
-      "treeRoot",
+      'treeRoot',
       EmberObject.create({
-        label: "ScienceBase Default",
-        icon: "globe",
+        label: 'ScienceBase Default',
+        icon: 'globe',
         checkable: false,
         isExpanded: true,
         draggable: false,
@@ -35,15 +40,15 @@ export default Component.extend({
         hideToggle: true,
         hideCheck: true,
         isRoot: true,
-        nodeClass: "sb-tree-root",
+        nodeClass: 'sb-tree-root',
         sbId: getWithDefault(
           settings,
-          "sb-defaultParent",
-          get(config, "defaultParent")
+          'sb-defaultParent',
+          get(config, 'defaultParent')
         ),
         config: config,
         willDestroy() {
-          let children = this.get("children");
+          let children = this.get('children');
           if (children) {
             children.forEach((itm) => {
               itm.destroy();
@@ -54,45 +59,45 @@ export default Component.extend({
     );
   },
 
-  classNames: ["sb-publisher"],
+  classNames: ['sb-publisher'],
   store: service(),
   settings: service(),
-  publishService: service("publish"),
-  config: computed("publishService", function () {
-    return this.get("publishService.catalogs").findBy("name", "ScienceBase");
+  publishService: service('publish'),
+  config: computed('publishService', function () {
+    return this.get('publishService.catalogs').findBy('name', 'ScienceBase');
   }),
-  tokenService: service("token"),
+  tokenService: service('token'),
 
   selected: A(),
 
-  publishable: computed("selected", "selected.[]", "isPublishing", function () {
-    if (this.get("isPublishing")) {
+  publishable: computed('selected', 'selected.[]', 'isPublishing', function () {
+    if (this.get('isPublishing')) {
       return [];
     }
-    return this.get("selected").filter((itm) => {
-      let path = get(itm, "path");
-      let length = get(path, "length");
+    return this.get('selected').filter((itm) => {
+      let path = get(itm, 'path');
+      let length = get(path, 'length');
 
       return (
-        itm.get("sbParentId") ||
+        itm.get('sbParentId') ||
         length < 3 ||
-        path.objectAt(length - 2).get("isSelected")
+        path.objectAt(length - 2).get('isSelected')
       );
     });
   }),
 
-  canPublish: bool("publishable.length"),
-  records: computed("store", function () {
-    return this.get("store").peekAll("record").rejectBy("hasSchemaErrors");
+  canPublish: bool('publishable.length'),
+  records: computed('store', function () {
+    return this.get('store').peekAll('record').rejectBy('hasSchemaErrors');
   }),
-  hasToken: bool("tokenService.token"),
+  hasToken: bool('tokenService.token'),
 
   model: computed(
-    "records.@each.recordId",
-    "records.@each.parentIds",
+    'records.@each.recordId',
+    'records.@each.parentIds',
     function () {
-      let all = this.get("records");
-      let records = all.rejectBy("hasParent");
+      let all = this.get('records');
+      let records = all.rejectBy('hasParent');
       if (isEmpty(records)) {
         return null;
       }
@@ -101,67 +106,72 @@ export default Component.extend({
         let children = node.addChildren(all);
         if (children) {
           children.forEach((itm) => {
-            set(itm, "parentNode", node);
+            set(itm, 'parentNode', node);
             itm.addChildren(all);
           });
         }
         return node;
       });
-      let treeRoot = this.get("treeRoot");
-      treeRoot.set("children", tree);
+      let treeRoot = this.get('treeRoot');
+      treeRoot.set('children', tree);
       return [treeRoot];
     }
   ),
 
   willDestroyElement() {
     this._super(...arguments);
-    let selected = this.get("selected");
-    selected.forEach((itm) => set(itm, "isSelected", false));
+    let selected = this.get('selected');
+    selected.forEach((itm) => set(itm, 'isSelected', false));
     selected.clear();
-    this.get("treeRoot").destroy();
+    this.get('treeRoot').destroy();
   },
 
   createNode(rec) {
-    let config = this.get("config");
-    let publishOptions = this.get("settings.data.publishOptions") || [];
-    let settings = publishOptions.find(option => option.catalog === 'ScienceBase') || {};
+    let config = this.get('config');
+    let publishOptions = this.get('settings.data.publishOptions') || [];
+    // Support both legacy 'catalog' field and new 'publisher' field
+    let settings =
+      publishOptions.find(
+        (option) =>
+          option.catalog === 'ScienceBase' || option.publisher === 'ScienceBase'
+      ) || {};
     setProperties(config, {
       defaultParent: getWithDefault(
         settings,
-        "sb-defaultParent",
-        get(config, "defaultParent")
+        'sb-defaultParent',
+        get(config, 'defaultParent')
       ),
-      defaultCommunity: get(settings, "sb-defaultCommunity"),
-      defaultOrganization: get(settings, "sb-defaultOrganization"),
+      defaultCommunity: get(settings, 'sb-defaultCommunity'),
+      defaultOrganization: get(settings, 'sb-defaultOrganization'),
     });
     return TreeNode.create({
       _record: rec,
-      config: this.get("config"),
-      settings: settings
+      config: this.get('config'),
+      settings: settings,
     });
   },
 
   actions: {
     hash(val) {
-      this.set("password", btoa(val));
+      this.set('password', btoa(val));
     },
 
     publish() {
-      let selected = this.get("publishable").filter(
+      let selected = this.get('publishable').filter(
         (itm) =>
-          get(itm, "path.length") < 3 || !get(itm, "parentNode.isSelected")
+          get(itm, 'path.length') < 3 || !get(itm, 'parentNode.isSelected')
       );
-      this.set("isPublishing", true);
+      this.set('isPublishing', true);
       const promises = selected.map((record) => {
-        set(record, "isLoading", true);
+        set(record, 'isLoading', true);
         return record.publish(this.tokenService.token);
       });
       allSettled(promises).then(
         () => {
-          set(this, "isPublishing", false);
+          set(this, 'isPublishing', false);
         },
         () => {
-          get(this, "flashMessages").danger("Publishing error!");
+          get(this, 'flashMessages').danger('Publishing error!');
         }
       );
     },
@@ -169,27 +179,27 @@ export default Component.extend({
     addToken() {
       const token = this.tokenService.addToken(this.rawToken);
       if (!token) {
-        set(this, "rawToken", null);
+        set(this, 'rawToken', null);
       }
     },
 
     selectRecord(nodeModel, path) {
-      let selected = this.get("selected");
-      let target = selected.findBy("id", get(nodeModel, "id"));
+      let selected = this.get('selected');
+      let target = selected.findBy('id', get(nodeModel, 'id'));
       if (
-        get(nodeModel, "isSelected") &&
+        get(nodeModel, 'isSelected') &&
         target === undefined &&
-        !nodeModel.get("notSelectable")
+        !nodeModel.get('notSelectable')
       ) {
-        set(nodeModel, "path", path);
+        set(nodeModel, 'path', path);
         selected.pushObject(nodeModel);
       } else {
         selected.removeObject(target);
-        set(nodeModel, "path", []);
-        let nodeChildren = nodeModel.get("children") || [];
+        set(nodeModel, 'path', []);
+        let nodeChildren = nodeModel.get('children') || [];
         nodeChildren.forEach(function (itm) {
-          if (itm.get("notSelectable") && itm.get("isSelected")) {
-            set(itm, "isSelected", false);
+          if (itm.get('notSelectable') && itm.get('isSelected')) {
+            set(itm, 'isSelected', false);
             this.actions.selectRecord.call(this, itm);
           }
         }, this);

--- a/lib/mdeditor-sciencebase/addon/templates/components/sb-settings.hbs
+++ b/lib/mdeditor-sciencebase/addon/templates/components/sb-settings.hbs
@@ -6,10 +6,10 @@
     change=save
   }}
   {{input/md-input
-    label="Publishing Endpoint"
-    value=model.sb-publishEndpoint
-    placeholder="Enter the endpoint for a publishing service."
-    change=save
+    label="Publisher Endpoint"
+    value=@model.publisherEndpoint
+    placeholder="Enter the main endpoint URL for the ScienceBase publisher."
+    change=@save
   }}
   {{!-- {{input/md-input
     label="Default Community"

--- a/lib/mdeditor-sciencebase/addon/utils/config.js
+++ b/lib/mdeditor-sciencebase/addon/utils/config.js
@@ -1,11 +1,11 @@
 export default {
-  name: "ScienceBase",
-  route: "sciencebase",
+  name: 'ScienceBase',
+  route: 'sciencebase',
   description:
-    "ScienceBase is a collaborative scientific data and information management platform",
-  icon: "globe",
-  rootURI: "https://api.sciencebase.gov/sbmd-service/",
-  rootItemURL: "https://www.sciencebase.gov/catalog/item/",
-  defaultParent: "59ef8a34e4b0220bbd98d449",
-  settingsComponent: "sb-settings",
+    'ScienceBase is a collaborative scientific data and information management platform',
+  icon: 'globe',
+  // rootURI: "https://api.sciencebase.gov/sbmd-service/",
+  rootItemURL: 'https://www.sciencebase.gov/catalog/item/',
+  defaultParent: '59ef8a34e4b0220bbd98d449',
+  settingsComponent: 'sb-settings',
 };

--- a/lib/mdeditor-sciencebase/addon/utils/sb-tree-node.js
+++ b/lib/mdeditor-sciencebase/addon/utils/sb-tree-node.js
@@ -1,43 +1,43 @@
-import { alias, bool } from "@ember/object/computed";
-import EmberObject from "@ember/object";
-import moment from "moment";
-import { A } from "@ember/array";
-import { allSettled } from "rsvp";
-import { isPresent } from "@ember/utils";
-import { computed, getWithDefault, get, set } from "@ember/object";
+import { alias, bool } from '@ember/object/computed';
+import EmberObject from '@ember/object';
+import moment from 'moment';
+import { A } from '@ember/array';
+import { allSettled } from 'rsvp';
+import { isPresent } from '@ember/utils';
+import { computed, getWithDefault, get, set } from '@ember/object';
 
-import $ from "jquery";
+import $ from 'jquery';
 
 export default EmberObject.extend({
   _record: null,
-  label: alias("_record.title"),
-  id: alias("_record.recordId"),
-  uuid: alias("id").readOnly(),
-  identifier: alias("id").readOnly(),
-  icon: alias("_record.icon"),
-  xhrError: alias("_record._xhrError"),
-  isSelected: alias("_record._isSelectedPub"),
-  type: alias("_record.defaultType"),
-  hideCheck: bool("_record.hasParent"),
+  label: alias('_record.title'),
+  id: alias('_record.recordId'),
+  uuid: alias('id').readOnly(),
+  identifier: alias('id').readOnly(),
+  icon: alias('_record.icon'),
+  xhrError: alias('_record._xhrError'),
+  isSelected: alias('_record._isSelectedPub'),
+  type: alias('_record.defaultType'),
+  hideCheck: bool('_record.hasParent'),
   isLoading: false,
   isExpanded: true,
   notSelectable: computed(
-    "sbId",
-    "isSelected",
-    "parentNode",
-    "parentNode.isSelected",
+    'sbId',
+    'isSelected',
+    'parentNode',
+    'parentNode.isSelected',
     function () {
-      let parent = this.get("parentNode");
+      let parent = this.get('parentNode');
 
       if (!isPresent(parent)) {
         return false;
       }
 
-      if (parent.get("isSelected")) {
+      if (parent.get('isSelected')) {
         return false;
       }
 
-      if (this.get("sbParentId")) {
+      if (this.get('sbParentId')) {
         return false;
       }
 
@@ -45,83 +45,83 @@ export default EmberObject.extend({
     }
   ),
 
-  sortOrder: computed("config.defaultParent", "sbParentId", function () {
-    let parent = this.get("sbParentId");
+  sortOrder: computed('config.defaultParent', 'sbParentId', function () {
+    let parent = this.get('sbParentId');
 
-    return !parent || this.get("config.defaultParent") === parent ? 0 : 1;
+    return !parent || this.get('config.defaultParent') === parent ? 0 : 1;
   }),
-  nodeClass: computed("sortOrder", function () {
-    return this.get("sortOrder") ? "tree-node-unrooted" : "tree-node-rooted";
+  nodeClass: computed('sortOrder', function () {
+    return this.get('sortOrder') ? 'tree-node-unrooted' : 'tree-node-rooted';
   }),
 
   draggable: true,
   definition: computed(
-    "_record.json.metadata.resourceInfo.abstract",
+    '_record.json.metadata.resourceInfo.abstract',
     function () {
-      return get(this, "_record.json.metadata.resourceInfo.abstract")
-        .split(" ")
+      return get(this, '_record.json.metadata.resourceInfo.abstract')
+        .split(' ')
         .splice(0, 50)
-        .join(" ");
+        .join(' ');
     }
   ),
 
   sbId: computed(
-    "_record.json.metadata.resourceInfo.citation.identifier.@each.identifier",
+    '_record.json.metadata.resourceInfo.citation.identifier.@each.identifier',
     function () {
-      let record = this.get("_record");
+      let record = this.get('_record');
 
       return this.findSbId(record);
     }
   ),
 
   sbParentId: computed(
-    "_record.parentIds.@each.identifier",
-    "_record.defaultParent",
+    '_record.parentIds.@each.identifier',
+    '_record.defaultParent',
     function () {
-      let parentIds = this.get("_record.parentIds");
+      let parentIds = this.get('_record.parentIds');
 
       if (!parentIds) {
         return false;
       }
 
-      let primary = parentIds.findBy("namespace", "gov.sciencebase.catalog");
+      let primary = parentIds.findBy('namespace', 'gov.sciencebase.catalog');
 
       if (primary) {
-        return get(primary, "identifier");
+        return get(primary, 'identifier');
       }
 
-      return this.findSbId(this.get("_record.defaultParent"));
+      return this.findSbId(this.get('_record.defaultParent'));
     }
   ),
 
-  sbParentIdObj: computed("sbParentId", function () {
-    let record = get(this, "_record");
-    let path = "json.metadata.metadataInfo.parentMetadata.identifier";
+  sbParentIdObj: computed('sbParentId', function () {
+    let record = get(this, '_record');
+    let path = 'json.metadata.metadataInfo.parentMetadata.identifier';
     let ids = get(record, path);
 
     if (ids) {
-      return ids.findBy("namespace", "gov.sciencebase.catalog");
+      return ids.findBy('namespace', 'gov.sciencebase.catalog');
     }
 
     return null;
   }),
 
-  sbDate: computed("sbId", function () {
-    let record = this.findSbIdObject(this.get("_record"));
-    let dates = record ? get(record, "authority.date") : null;
+  sbDate: computed('sbId', function () {
+    let record = this.findSbIdObject(this.get('_record'));
+    let dates = record ? get(record, 'authority.date') : null;
 
-    if (dates && get(dates, "length")) {
-      let published = dates.filterBy("dateType", "published");
+    if (dates && get(dates, 'length')) {
+      let published = dates.filterBy('dateType', 'published');
 
       if (!published) {
         return null;
       }
 
-      if (get(published, "length") === 1) {
-        return get(published, "firstObject.date");
+      if (get(published, 'length') === 1) {
+        return get(published, 'firstObject.date');
       }
 
-      return published.mapBy("date").reduce(function (a, b) {
+      return published.mapBy('date').reduce(function (a, b) {
         return moment.max(moment(a), moment(b));
       });
     }
@@ -130,7 +130,7 @@ export default EmberObject.extend({
   }),
 
   willDestroy() {
-    this.get("children").forEach((itm) => {
+    this.get('children').forEach((itm) => {
       itm.destroy();
     });
   },
@@ -140,12 +140,12 @@ export default EmberObject.extend({
       return null;
     }
 
-    if (record.get("recordIdNamespace") === "gov.sciencebase.catalog") {
-      return record.get("json.metadata.metadataInfo.metadataIdentifier");
+    if (record.get('recordIdNamespace') === 'gov.sciencebase.catalog') {
+      return record.get('json.metadata.metadataInfo.metadataIdentifier');
     }
 
-    let ids = record.get("json.metadata.resourceInfo.citation.identifier");
-    let id = ids ? ids.findBy("namespace", "gov.sciencebase.catalog") : null;
+    let ids = record.get('json.metadata.resourceInfo.citation.identifier');
+    let id = ids ? ids.findBy('namespace', 'gov.sciencebase.catalog') : null;
 
     return id;
   },
@@ -157,12 +157,12 @@ export default EmberObject.extend({
 
     let id = this.findSbIdObject(record);
 
-    return id ? get(id, "identifier") : null;
+    return id ? get(id, 'identifier') : null;
   },
 
   addSbId(id) {
-    let record = get(this, "_record");
-    let path = "json.metadata.resourceInfo.citation.identifier";
+    let record = get(this, '_record');
+    let path = 'json.metadata.resourceInfo.citation.identifier';
     let arr = A();
 
     set(record, path, getWithDefault(record, path, arr));
@@ -172,29 +172,29 @@ export default EmberObject.extend({
         date: [
           {
             date: moment().toISOString(),
-            dateType: "published",
-            description: "Published using mdEditor",
+            dateType: 'published',
+            description: 'Published using mdEditor',
           },
         ],
-        title: "ScienceBase",
+        title: 'ScienceBase',
       },
       identifier: id,
-      namespace: "gov.sciencebase.catalog",
-      description: "Identifier imported from ScienceBase during publication",
+      namespace: 'gov.sciencebase.catalog',
+      description: 'Identifier imported from ScienceBase during publication',
     });
   },
 
   addSbParentId(id) {
-    let record = get(this, "_record");
-    let path = "json.metadata.metadataInfo.parentMetadata";
-    let idPath = path + ".identifier";
+    let record = get(this, '_record');
+    let path = 'json.metadata.metadataInfo.parentMetadata';
+    let idPath = path + '.identifier';
     let arr = A();
 
     set(
       record,
       path,
       getWithDefault(record, path, {
-        title: "Parent Metadata",
+        title: 'Parent Metadata',
       })
     );
 
@@ -205,33 +205,33 @@ export default EmberObject.extend({
         date: [
           {
             date: moment().toISOString(),
-            dateType: "published",
-            description: "Published using mdEditor",
+            dateType: 'published',
+            description: 'Published using mdEditor',
           },
         ],
-        title: "ScienceBase",
+        title: 'ScienceBase',
       },
       identifier: id,
-      namespace: "gov.sciencebase.catalog",
-      description: "Identifier imported from ScienceBase during publication",
+      namespace: 'gov.sciencebase.catalog',
+      description: 'Identifier imported from ScienceBase during publication',
     });
   },
 
   updateSbParentId() {
-    let record = get(this, "_record");
-    let path = "json.metadata.metadataInfo.parentMetadata.identifier";
-    let id = get(record, path).findBy("namespace", "gov.sciencebase.catalog");
+    let record = get(this, '_record');
+    let path = 'json.metadata.metadataInfo.parentMetadata.identifier';
+    let id = get(record, path).findBy('namespace', 'gov.sciencebase.catalog');
 
     if (id) {
-      set(id, "authority", {
+      set(id, 'authority', {
         date: [
           {
             date: moment().toISOString(),
-            dateType: "published",
-            description: "Published using mdEditor",
+            dateType: 'published',
+            description: 'Published using mdEditor',
           },
         ],
-        title: "ScienceBase",
+        title: 'ScienceBase',
       });
     }
   },
@@ -239,151 +239,155 @@ export default EmberObject.extend({
   addChildren(records) {
     let children = records
       .filter((itm) => {
-        let parentIds = itm.get("parentIds");
+        let parentIds = itm.get('parentIds');
 
         if (!parentIds) {
           return false;
         }
 
-        return parentIds.findBy("identifier", get(this, "id"));
+        return parentIds.findBy('identifier', get(this, 'id'));
       })
       .map((rec) => {
         return this.constructor.create({
           _record: rec,
-          config: this.get("config"),
+          config: this.get('config'),
         });
       });
 
-    set(this, "children", children);
+    set(this, 'children', children);
 
     return children;
   },
 
   publish(refreshToken) {
     let record = this;
-    let sbId = record.get("sbId");
-    let publishOptions = record.get("settings");
+    let sbId = record.get('sbId');
+    let publishOptions = record.get('settings');
     let rootURI = getWithDefault(
       publishOptions,
-      "sb-publishEndpoint",
-      this.get("config.rootURI")
+      'publisherEndpoint',
+      getWithDefault(
+        publishOptions,
+        'sb-publishEndpoint',
+        this.get('config.rootURI')
+      )
     );
-    let defaultParent = this.get("config.defaultParent");
+    let defaultParent = this.get('config.defaultParent');
     let url =
-      record.get("type") === "project"
-        ? rootURI + "project"
-        : rootURI + "product";
-    let urlPut = sbId ? "/" + sbId : "";
+      record.get('type') === 'project'
+        ? rootURI + 'project'
+        : rootURI + 'product';
+    let urlPut = sbId ? '/' + sbId : '';
 
     let data = {
       data: {
         parentid:
-          record.get("sbParentId") ||
-          record.get("parentNode.sbId") ||
+          record.get('sbParentId') ||
+          record.get('parentNode.sbId') ||
           defaultParent,
         community_id:
-          record.get("sbParentId") ||
-          record.get("parentNode.sbId") ||
+          record.get('sbParentId') ||
+          record.get('parentNode.sbId') ||
           defaultParent,
-        mdjson: record.get("_record.formatted"),
-        type: "records",
+        mdjson: record.get('_record.formatted'),
+        type: 'records',
         refresh_token: refreshToken,
       },
     };
 
     record.setProperties({
       isLoading: true,
-      "_record._xhrError": false,
+      '_record._xhrError': false,
       result: null,
     });
 
-    record.notifyPropertyChange("isLoading");
+    record.notifyPropertyChange('isLoading');
 
     let promise = $.ajax(url + urlPut, {
-      type: sbId ? "PUT" : "POST",
+      type: sbId ? 'PUT' : 'POST',
       data: JSON.stringify(data),
-      contentType: "application/json; charset=utf-8",
-      dataType: "json",
+      contentType: 'application/json; charset=utf-8',
+      dataType: 'json',
       context: this,
     }).then(
       function (response) {
-        set(record, "isLoading", false);
+        set(record, 'isLoading', false);
 
         if (response.id) {
           if (!sbId) {
             record.addSbId(response.id);
           } else if (sbId !== response.id) {
-            let error = "Publishing error! ScienceBase identifier mismatch!";
+            let error = 'Publishing error! ScienceBase identifier mismatch!';
 
-            set(record, "_record._xhrError", [error]);
+            set(record, '_record._xhrError', [error]);
 
             throw new Error(error);
           }
 
-          if (!record.get("sbParentId")) {
+          if (!record.get('sbParentId')) {
             record.addSbParentId(response.parentId);
           } else {
             record.updateSbParentId();
           }
 
-          let idObj = record.findSbIdObject(record.get("_record"));
+          let idObj = record.findSbIdObject(record.get('_record'));
 
           if (idObj) {
             //make sure we have an authority and a date
             set(
               idObj,
-              "authority",
-              getWithDefault(idObj, "authority", {
+              'authority',
+              getWithDefault(idObj, 'authority', {
                 date: [],
-                title: "ScienceBase",
+                title: 'ScienceBase',
               })
             );
             set(
               idObj,
-              "authority.title",
-              getWithDefault(idObj, "authority.title", "ScienceBase")
+              'authority.title',
+              getWithDefault(idObj, 'authority.title', 'ScienceBase')
             );
             set(
               idObj,
-              "authority.date",
-              getWithDefault(idObj, "authority.date", [])
+              'authority.date',
+              getWithDefault(idObj, 'authority.date', [])
             );
 
-            get(idObj, "authority.date").pushObject({
+            get(idObj, 'authority.date').pushObject({
               date: moment().toISOString(),
-              dateType: "published",
-              description: "Published using mdEditor",
+              dateType: 'published',
+              description: 'Published using mdEditor',
             });
 
-            record.notifyPropertyChange("sbDate");
+            record.notifyPropertyChange('sbDate');
           }
 
-          set(this, "result", response);
-          record.notifyPropertyChange("_record.defaultParent");
+          set(this, 'result', response);
+          record.notifyPropertyChange('_record.defaultParent');
 
-          record.get("_record").save();
+          record.get('_record').save();
 
           return allSettled(
-            record.children.filterBy("isSelected").map((child) => {
-              set(child, "isLoading", true);
+            record.children.filterBy('isSelected').map((child) => {
+              set(child, 'isLoading', true);
               return child.publish(refreshToken);
             })
           );
         } else {
-          set(this, "errors", response.error);
+          set(this, 'errors', response.error);
           // get(this, 'flashMessages')
           //   .danger('Publishing error!');
-          throw new Error("Publishing error!");
+          throw new Error('Publishing error!');
         }
       },
       (response) => {
         let error = `Error Publishing: ${response.status}: ${response.statusText}`;
-        let xhrError = get(response, "responseJSON.error.messages") || [];
+        let xhrError = get(response, 'responseJSON.error.messages') || [];
 
         xhrError.unshift(error);
 
-        set(record, "isLoading", false);
-        set(this, "_record._xhrError", xhrError);
+        set(record, 'isLoading', false);
+        set(this, '_record._xhrError', xhrError);
 
         throw new Error(xhrError);
       }

--- a/tests/integration/components/sb-publisher-test.js
+++ b/tests/integration/components/sb-publisher-test.js
@@ -25,7 +25,7 @@ module("Integration | Component | sb publisher", function (hooks) {
       "settings",
       EmberObject.create({
         data: {
-          publishOptions: {},
+          publishOptions: [],
         },
       })
     );


### PR DESCRIPTION
## 🚀 Benefits of Feature

- Extensibility: Easy to add new publishing/sync services in the future
- Consistency: Publishing settings now follow same array pattern as other settings
- User Experience: Default values reduce repetitive data entry for sync operations
- Maintainability: Cleaner separation of concerns between different publishing services

## 📁 Files Changed
### Core Settings Infrastructure
- app/models/setting.js - Changed `publishOptions` default from object to array
- app/pods/settings/route.js - Added `getPublishOptions` action to manage catalog-specific settings
- app/pods/settings/main/template.hbs - Updated to use new catalog-based settings structure

### Publishing System Updates
- utils/couchdb-config.js - New CouchDB catalog configuration
- app/instance-initializers/settings-couchdb.js - Register CouchDB in publishing system
- app/pods/components/couchdb-settings/ - New component for CouchDB configuration UI

### Publish Route Structure
- app/router.js - Added  `couchdb` route under publish
- app/pods/publish/couchdb/route.js - New route for CouchDB publish page
- app/pods/publish/couchdb/template.hbs - Informational page explaining sync vs. publish

### Sync Integration
- app/pods/components/control/md-couch-login/component.js - Enhanced to load default settings
- app/pods/components/control/md-couch-login/template.hbs - Updated to trigger defaults loading

### ScienceBase Compatibility
- lib/mdeditor-sciencebase/addon/components/sb-publisher.js - Updated to work with array structure
- tests/integration/components/sb-publisher-test.js - Updated test data structure


## 🧪 Testing Instructions
### Test Publishing Settings Refactor:

1. Go to Settings → Main → Publishing Settings
2. Verify both ScienceBase and CouchDB panels appear
3. Configure settings in both panels and save
4. Check that settings persist and are stored as array in browser storage

### Test CouchDB Integration:

1. Configure CouchDB defaults in Settings → Publishing Settings → CouchDB
      - Set URL: https://example.com:5984
      - Set Database: test-db
      - Set Username: testuser

2. Navigate to Sync page
3. Verify the login form is pre-populated with configured defaults
4. Confirm password field remains empty (security feature)

### Test Publishing Routes:

1. Go to Publish page
2. Verify both "ScienceBase" and "CouchDB" options appear
3. Click "CouchDB" option
4. Verify informational page displays with clear guidance
5. Test navigation links to Settings and Sync pages

### Test Backward Compatibility:

1. Verify existing ScienceBase publishing functionality still works
2. Test that users with existing ScienceBase settings don't lose configuration
3. Confirm ScienceBase publisher component continues to function normally

## 📝 Additional Notes

- CouchDB uses sync rather than traditional publishing, so the publish route provides educational content and navigation
- Default settings loading uses scheduleOnce to prevent Ember revalidation errors
- All property names with dashes use safe accessor patterns to prevent JavaScript errors

## Closing issues
closes #726 
closes #756 
closes #764
closes #751

## Pull Request

* **Please check if the PR fulfills these requirements**
  - [x] The commit message follows our guidelines
  - [x] Tests for the changes have been added (for bug fixes / features)
  ~~- [ ] Docs have been added / updated (for bug fixes / features)~~
