### PR TITLE
Refactor API configuration trap check for only `.xml` file types

### DIFF
--- a/app/pods/components/md-translate/component.js
+++ b/app/pods/components/md-translate/component.js
@@ -23,6 +23,7 @@ export default Component.extend({
   mdjson: service(),
   settings: service(),
   ajax: service(),
+  apiValidator: service(),
 
   /**
    * Indicates whether empty tags should be written to the translated output
@@ -130,6 +131,9 @@ export default Component.extend({
   isJson: equal('writerType', 'json'),
   defaultAPI: defaultValues.mdTranslatorAPI,
   apiURL: or('settings.data.mdTranslatorAPI', 'defaultAPI'),
+  isApiConfigured: computed('settings.data.mdTranslatorAPI', function () {
+    return this.apiValidator.isApiConfigured();
+  }),
   isHtml: computed('writerType', function () {
     //IE does not supoprt srcdoc, so default to non-html display
     return (
@@ -148,6 +152,14 @@ export default Component.extend({
 
   actions: {
     translate() {
+      // Check if API is configured before proceeding
+      if (!this.apiValidator.isApiConfigured()) {
+        this.flashMessages.danger(
+          'mdTranslator API URL is not configured. Please configure it in Settings.'
+        );
+        return;
+      }
+
       let mdjson = this.mdjson;
       let url = this.apiURL;
       let cmp = this;
@@ -257,6 +269,11 @@ export default Component.extend({
             .trim()
             .replace(/^([A-Z]{2,})/g, (match) => match.toLowerCase())
         : 'context not provided';
+    },
+    goToSettings() {
+      // This action should be handled by the parent route/controller
+      // We'll send the action up the component hierarchy
+      this.sendAction('goToSettings');
     },
   },
 });

--- a/app/pods/components/md-translate/template.hbs
+++ b/app/pods/components/md-translate/template.hbs
@@ -52,9 +52,15 @@
                 </div>
             </div>
             <div class="card-footer">
+                {{#unless this.isApiConfigured}}
+                    <div class="alert alert-warning" role="alert">
+                        <strong>Warning:</strong> mdTranslator API URL is not configured. Please configure it in
+                        <a href="#" {{action "goToSettings"}}>Settings</a> to enable translation.
+                    </div>
+                {{/unless}}
                 {{control/md-status model=model isBtn=true bntSize="lg"}}
                 <button type="submit" class="btn btn-lg btn-primary pull-right"
-                disabled={{if writer false true}}>
+                disabled={{or (not this.writer) (not this.isApiConfigured)}}>
                     {{fa-icon "retweet"}} Translate </button>
             </div>
         </form>

--- a/app/pods/import/route.js
+++ b/app/pods/import/route.js
@@ -356,16 +356,15 @@ export default Route.extend(ScrollTo, {
       let cmp = this;
 
       new Promise((resolve, reject) => {
-        // Check API configuration first
-        if (!this.checkApiConfiguration()) {
-          reject(
-            'mdTranslator API URL is not configured. Please configure it in Settings.'
-          );
-          return;
-        }
-
-        // Then check file type specifics
+        // Check file type first
         if (file.type.match(/.*\/xml$/)) {
+          // Check API configuration for XML files only
+          if (!this.checkApiConfiguration()) {
+            reject(
+              'mdTranslator API URL is not configured. Please configure it in Settings.'
+            );
+            return;
+          }
           // If it's XML, proceed with XML translation
           set(controller, 'isTranslating', true);
           this.flashMessages.info(`Translation service provided by ${url}.`);
@@ -440,14 +439,6 @@ export default Route.extend(ScrollTo, {
       let uri = this.controller.get('importUri');
       let controller = this.controller;
       let route = this;
-
-      // Check API configuration first
-      if (!this.checkApiConfiguration()) {
-        this.flashMessages.danger(
-          'mdTranslator API URL is not configured. Please configure it in Settings.'
-        );
-        return;
-      }
 
       set(controller, 'isLoading', true);
 

--- a/app/pods/import/route.js
+++ b/app/pods/import/route.js
@@ -19,6 +19,7 @@ export default Route.extend(ScrollTo, {
   jsonvalidator: service(),
   settings: service(),
   ajax: service(),
+  apiValidator: service(),
 
   init() {
     this._super(...arguments);
@@ -324,12 +325,8 @@ export default Route.extend(ScrollTo, {
   },
 
   checkApiConfiguration() {
-    // Check if mdTranslatorAPI is configured
-    if (
-      this.get('settings.data.mdTranslatorAPI') === null ||
-      this.get('settings.data.mdTranslatorAPI') === undefined ||
-      this.get('settings.data.mdTranslatorAPI') === ''
-    ) {
+    // Check if mdTranslatorAPI is configured using the service
+    if (!this.apiValidator.isApiConfigured()) {
       // Show modal to alert user
       console.log('mdTranslator API is not configured');
       this.controller.set('showApiModal', true);

--- a/app/pods/record/show/translate/route.js
+++ b/app/pods/record/show/translate/route.js
@@ -1,14 +1,19 @@
 import Route from '@ember/routing/route';
 
 export default Route.extend({
-setupController(controller, model) {
-  this._super(controller, model);
+  setupController(controller, model) {
+    this._super(controller, model);
 
-  controller.setProperties({
-    writer: controller.writer || null,
-    forceValid: controller.forceValid || false,
-    showAllTags: controller.showAllTags || false
-  });
-},
+    controller.setProperties({
+      writer: controller.writer || null,
+      forceValid: controller.forceValid || false,
+      showAllTags: controller.showAllTags || false,
+    });
+  },
 
+  actions: {
+    goToSettings() {
+      this.transitionTo('settings.main');
+    },
+  },
 });

--- a/app/pods/record/show/translate/template.hbs
+++ b/app/pods/record/show/translate/template.hbs
@@ -7,6 +7,7 @@
           writer=writer
           forceValid=forceValid
           showAllTags=showAllTags
+          goToSettings=(route-action "goToSettings")
         }}
     </div>
 </div>

--- a/app/services/api-validator.js
+++ b/app/services/api-validator.js
@@ -1,0 +1,37 @@
+import Service from '@ember/service';
+import { inject as service } from '@ember/service';
+
+export default Service.extend({
+  settings: service(),
+
+  /**
+   * Checks if the mdTranslator API is properly configured
+   * @returns {Boolean} true if API is configured, false otherwise
+   */
+  isApiConfigured() {
+    const apiUrl = this.get('settings.data.mdTranslatorAPI');
+    return !!(apiUrl && apiUrl.trim() !== '');
+  },
+
+  /**
+   * Validates API configuration and throws an error if not configured
+   * @throws {Error} If API is not configured
+   */
+  validateApiConfiguration() {
+    if (!this.isApiConfigured()) {
+      throw new Error(
+        'mdTranslator API URL is not configured. Please configure it in Settings.'
+      );
+    }
+  },
+
+  /**
+   * Gets the configured API URL or throws an error if not configured
+   * @returns {String} The configured API URL
+   * @throws {Error} If API is not configured
+   */
+  getApiUrl() {
+    this.validateApiConfiguration();
+    return this.get('settings.data.mdTranslatorAPI');
+  },
+});


### PR DESCRIPTION
### Closing issues
closes #738 

## Pull Request

* **Please check if the PR fulfills these requirements**
  - [x] The commit message follows our guidelines
  - [x] Tests for the changes have been added (for bug fixes / features)
  ~~- [ ] Docs have been added / updated (for bug fixes / features)~~


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

- Only allows the trap check for a blank `mdTranslator` `api` for `.xml` file types and if the user creates a new record and want to `translate` that record they will need to also include a `mdTranslatorAPI`

* **What is the current behavior?** (You can also link to an open issue here)
- Trap triggers for all file types imported and if there is a missing `mdTranslatorApi`


* **What is the new behavior (if this is a feature change)?**
- Trap works only for `.xml` file types


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
- no
