### PR TITLE
Dynamically grab the schema version from `package.json` 

### DIFF
--- a/app/models/record.js
+++ b/app/models/record.js
@@ -72,10 +72,13 @@ const Record = Model.extend(Validations, Copyable, {
   }),
   json: attr('json', {
     defaultValue() {
+      const mdjsonService = getOwner(this).lookup('service:mdjson');
+      const schemaVersion = mdjsonService.getSchemaVersion();
+
       const obj = EmberObject.create({
         schema: {
           name: 'mdJson',
-          version: '2.6.0',
+          version: schemaVersion,
         },
         metadata: {
           metadataInfo: {

--- a/app/services/mdjson.js
+++ b/app/services/mdjson.js
@@ -41,6 +41,10 @@ export default Service.extend({
   contacts: service(),
   store: service(),
 
+  getSchemaVersion() {
+    return Schemas.schema.version;
+  },
+
   injectCitations(json) {
     let assoc = json.metadata.associatedResource;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6368,9 +6368,9 @@ __metadata:
   linkType: hard
 
 "caniuse-lite@npm:^1.0.0, caniuse-lite@npm:^1.0.30000844, caniuse-lite@npm:^1.0.30001688":
-  version: 1.0.30001703
-  resolution: "caniuse-lite@npm:1.0.30001703"
-  checksum: 10c0/ed88e318da28e9e59c4ac3a2e3c42859558b7b713aebf03696a1f916e4ed4b70734dda82be04635e2b62ec355b8639bbed829b7b12ff528d7f9cc31a3a5bea91
+  version: 1.0.30001734
+  resolution: "caniuse-lite@npm:1.0.30001734"
+  checksum: 10c0/5869cb6a01e7a012a8c5d7b0482e2c910be3a2a469d4ef516a54db3f846fbaedb2600eeaa270dae9e2ad9328e33f39782e6f459405fcca620021f5f06694542d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Changes Made:
1. Added a method to the `mdjson` service:
    - Added `getSchemaVersion()` method that returns `Schemas.schemas.version`
    - This provides access to the version from the `mdjson-schemas` package.

2. Modified the record model `record.js`
    - Updated the `defaultValue` function for the `json` attribute
    - Used `getOwner(this).lookup('service:mdjson')` to access the `mdjson` service
    - Called `getSchemaVersion() to get the dynamic version 
    - Replaced the hardcoded `2.6.0` with the dynamic version

### Key Benefits: 

1. Dynamic Version Management: The sehcma version is now automatically puleed from the `mdjson-schemas` dependency.
2. No More Hardcoded Values: Eliminates the need to manually update the version in the code when the dependency is update
3. Single Source of Truth: The version comes directly from the `mdjson-schemas` package, ensuring consistency
4. Backward Compatibility:  The implementation doesn't break any existing functionality


### Closing issues

closes #768 

## Pull Request

* **Please check if the PR fulfills these requirements**
  - [x] The commit message follows our guidelines
  -~~ [ ] Tests for the changes have been added (for bug fixes / features)~~
  ~~- [ ] Docs have been added / updated (for bug fixes / features)~~
  
  
<img width="2145" height="572" alt="image" src="https://github.com/user-attachments/assets/d515d814-52e8-4b59-a7b2-832c189e7226" />
