### PR TITLE
Update gh-pages-deploy.yml

### DIFF
--- a/.github/workflows/gh-pages-deploy.yml
+++ b/.github/workflows/gh-pages-deploy.yml
@@ -14,7 +14,10 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: '16'
+          node-version: '18'
+
+      - name: enable corepack
+        run: corepack enable
 
       - name: Install Dependencies
         run: yarn install

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
   - Update CONTRIBUTING.md (no trailing slash for user specified settings) [#752](https://github.com/adiwg/mdEditor/issues/752)
   - Expose the `itis-proxy-url` as a user setting [#762](https://github.com/adiwg/mdEditor/issues/762)
   - Refactor ScienceBase user setting to support updated "publish-options" schema [#764](https://github.com/adiwg/mdEditor/issues/764)
+  - Update gh-pages-deploy.yml to use Node version 18 and enable corepack
 
 ### Bug fixes
 


### PR DESCRIPTION
Update gh-pages-deploy.yml to use Node version 18 and enable corepack