### PR TITLE
BUG: Fix translate menu bugs

### DIFF
--- a/app/pods/components/layout/md-breadcrumb/template.hbs
+++ b/app/pods/components/layout/md-breadcrumb/template.hbs
@@ -2,9 +2,15 @@
   {{#each this.routeHierarchy as |crumb|}}
     <li class="breadcrumb-item {{if crumb.isTail 'active'}}">
       {{#if (and crumb.linkable (not crumb.isTail))}}
-        <LinkTo @route={{crumb.path}} @model={{crumb.model}}>
-          {{crumb.title}}
-        </LinkTo>
+        {{#if crumb.model}}
+          <LinkTo @route={{crumb.path}} @model={{crumb.model}}>
+            {{crumb.title}}
+          </LinkTo>
+        {{else}}
+          <LinkTo @route={{crumb.path}}>
+            {{crumb.title}}
+          </LinkTo>
+        {{/if}}
       {{else}}
         {{crumb.title}}
       {{/if}}

--- a/app/pods/components/md-translate/component.js
+++ b/app/pods/components/md-translate/component.js
@@ -2,6 +2,7 @@ import { alias, equal, or } from '@ember/object/computed';
 import Component from '@ember/component';
 import classic from 'ember-classic-decorator';
 import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
 import { inject as service } from '@ember/service';
 import { Promise } from 'rsvp';
 import moment from 'moment';
@@ -46,12 +47,12 @@ export default class MdTranslateComponent extends Component {
   forceValid = false;
 
   writer = null;
-  result = null;
-  errorLevel = null;
-  errors = null;
-  xhrError = null;
-  isLoading = false;
-  subTitle = null;
+  @tracked result = null;
+  @tracked errorLevel = null;
+  @tracked errors = null;
+  @tracked xhrError = null;
+  @tracked isLoading = false;
+  @tracked subTitle = null;
 
   @alias('errors') messages;
   @equal('writerType', 'json') isJson;
@@ -147,7 +148,7 @@ export default class MdTranslateComponent extends Component {
 
   _clearResult() {
     this.result = null;
-    this.subtitle = null;
+    this.subTitle = null;
     this.errors = null;
     this.xhrError = null;
   }
@@ -278,8 +279,9 @@ export default class MdTranslateComponent extends Component {
 
   @action
   goToSettings() {
-    // This action should be handled by the parent route/controller
-    // We'll send the action up the component hierarchy
-    this.sendAction('goToSettings');
+    // Invoke the closure action passed from the parent route
+    if (this.onGoToSettings && typeof this.onGoToSettings === 'function') {
+      this.onGoToSettings();
+    }
   }
 }

--- a/app/pods/components/md-translate/template.hbs
+++ b/app/pods/components/md-translate/template.hbs
@@ -9,7 +9,8 @@
         <form {{action "translate" on="submit"}}>
             <div class="card-block">
                 {{input/md-select label="Choose Format"
-                  value=this.writer
+                  model=this
+                  path="writer"
                   valuePath="value"
                   namePath="name"
                   objectArray=this.writerOptions
@@ -85,7 +86,7 @@
         <h4 class="text-{{this.errorClass}}">{{this.errorSubTitle}}</h4>
         <ul class="list-group">
           {{#each this.messages as |message|}}
-            {{#with (compute (action "errorClass") message.[0]) as |errorClass|}}
+            {{#with (compute (action "errorClassAction") message.[0]) as |errorClass|}}
               <li class="list-group-item">
                 <div class="">
                   <h4 class="list-group-item-heading">

--- a/app/pods/record/show/translate/route.js
+++ b/app/pods/record/show/translate/route.js
@@ -4,8 +4,13 @@ import { inject as service } from '@ember/service';
 
 export default class TranslateRoute extends Route {
   @service router;
+
+  model() {
+    return this.modelFor('record.show');
+  }
+
   setupController(controller, model) {
-    this._super(controller, model);
+    super.setupController(controller, model);
 
     controller.setProperties({
       writer: controller.writer || null,
@@ -13,6 +18,7 @@ export default class TranslateRoute extends Route {
       showAllTags: controller.showAllTags || false,
     });
   }
+  @action
   goToSettings() {
     this.router.transitionTo('settings.main');
   }

--- a/app/pods/record/show/translate/template.hbs
+++ b/app/pods/record/show/translate/template.hbs
@@ -3,11 +3,10 @@
       <h3>Translate Record</h3>
         {{md-translate
           model=this.model
-          store=this.store
           writer=this.writer
           forceValid=this.forceValid
           showAllTags=this.showAllTags
-          goToSettings=(route-action "goToSettings")
+          onGoToSettings=(route-action "goToSettings")
         }}
     </div>
 </div>

--- a/app/pods/settings/main/route.js
+++ b/app/pods/settings/main/route.js
@@ -12,12 +12,8 @@ export default class MainRoute extends Route {
     return this.settings.get('data');
   }
 
+  @action
   setScrollTo(scrollTo) {
     this.controller.set('scrollTo', scrollTo || '');
-  }
-
-  @action
-  setScrollToAction(scrollTo) {
-    this.setScrollTo(scrollTo);
   }
 }

--- a/app/pods/settings/main/template.hbs
+++ b/app/pods/settings/main/template.hbs
@@ -66,7 +66,7 @@
         message="<h4 class=\"text-danger\"><span class=\"fa fa-exclamation-circle\"></span> <strong>Are you
             sure?</strong></h4> Clicking <strong class=\"text-danger\">Confirm</strong> will delete ALL records in
         your browser cache. Have you made a backup?"
-        confirm=(route-action "clearLocalStorage")
+        confirmAction=(route-action "clearLocalStorage")
         showCancel=true
         cancelType="primary"
         showConfirm=true

--- a/app/pods/settings/route.js
+++ b/app/pods/settings/route.js
@@ -46,6 +46,7 @@ export default class SettingsRoute extends Route {
     controller.set('links', links);
   }
 
+  @action
   clearLocalStorage() {
     let data = this.settings.data.serialize({ includeId: true });
 
@@ -66,14 +67,17 @@ export default class SettingsRoute extends Route {
     //this.transitionTo('application');
   }
 
+  @action
   save() {
     this.settings.data.save();
   }
 
+  @action
   catalogs() {
     return this.get('publish.catalogs');
   }
 
+  @action
   deriveItisProxyUrl() {
     let model = this.modelFor('settings.main');
     const mdTranslatorAPI = model.get('mdTranslatorAPI');
@@ -87,6 +91,7 @@ export default class SettingsRoute extends Route {
     }
   }
 
+  @action
   getPublishOptions(catalogName) {
     let model = this.modelFor('settings.main');
     let publishOptions = model.get('publishOptions') || [];


### PR DESCRIPTION
closes #800 

## Translate Menu Bug Fixes                                                                                                 
   
  ### Model Lifecycle (`app/models/base.js`)                                                                                     
  - Fixed timing issue by scheduling isReady after render to ensure applyPatch completes first
  - Added cleanup for dirty attributes state after save to prevent false dirty flags
  - Fixed a parameter bug in `setCurrentHash`

  ### Breadcrumb Navigation (md-breadcrumb/template.hbs, breadcrumbs.js)
  - Fixed LinkTo to conditionally include model only when needed (was breaking routes without dynamic segments)
  - Added `_routeRequiresModel()` to only pass models for routes with dynamic segments like record.show
  - Added validation that models have an id before using them

  ### Translate Component (`md-translate/`)
  - Converted properties to `@tracked` for proper reactivity (result, errors, isLoading, etc.)
  - Fixed typo: subtitle → subTitle
  - Modernized from deprecated `sendAction` to closure action pattern (`onGoToSettings`)
  - Fixed the select input binding pattern

  ### Route Modernization
  - Added `@action` decorators to route methods that were missing them (`settings/route.js, settings/main/route.js,
  translate/route.js`)
  - Changed `this._super()` to `super.setupController()`
  - Consolidated duplicate action methods in settings

  ### Template Fixes
  - Renamed confirm to `confirmAction` for `md-confirm-button`
  - Renamed action from `errorClass` to `errorClassAction` in translate template

  Overall: This is a modernization effort bringing the translate feature and related routes up to Ember Octane patterns
  (tracked properties, native classes, closure actions), while fixing breadcrumb navigation bugs for routes without dynamic
   segments.