### PR TITLE
BUG:  Fixed publish service errors

### DIFF
--- a/app/pods/components/control/md-couch-login/component.js
+++ b/app/pods/components/control/md-couch-login/component.js
@@ -25,7 +25,8 @@ export default class CouchLoginComponent extends Component {
 
   loadDefaults() {
     if (this.settings.data && !this.couch.loggedIn) {
-      const publishOptions = this.settings.data.publishOptions || [];
+      const rawOptions = this.settings.data.publishOptions;
+      const publishOptions = Array.isArray(rawOptions) ? rawOptions : [];
       // Support both legacy 'catalog' field and new 'publisher' field
       const couchdbSettings = publishOptions.find(
         (option) =>

--- a/app/pods/components/layout/md-breadcrumb/template.hbs
+++ b/app/pods/components/layout/md-breadcrumb/template.hbs
@@ -2,9 +2,15 @@
   {{#each this.routeHierarchy as |crumb|}}
     <li class="breadcrumb-item {{if crumb.isTail 'active'}}">
       {{#if (and crumb.linkable (not crumb.isTail))}}
-        <LinkTo @route={{crumb.path}} @model={{crumb.model}}>
-          {{crumb.title}}
-        </LinkTo>
+        {{#if crumb.model}}
+          <LinkTo @route={{crumb.path}} @model={{crumb.model}}>
+            {{crumb.title}}
+          </LinkTo>
+        {{else}}
+          <LinkTo @route={{crumb.path}}>
+            {{crumb.title}}
+          </LinkTo>
+        {{/if}}
       {{else}}
         {{crumb.title}}
       {{/if}}

--- a/app/pods/components/md-translate/component.js
+++ b/app/pods/components/md-translate/component.js
@@ -2,6 +2,7 @@ import { alias, equal, or } from '@ember/object/computed';
 import Component from '@ember/component';
 import classic from 'ember-classic-decorator';
 import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
 import { inject as service } from '@ember/service';
 import { Promise } from 'rsvp';
 import moment from 'moment';
@@ -46,12 +47,12 @@ export default class MdTranslateComponent extends Component {
   forceValid = false;
 
   writer = null;
-  result = null;
-  errorLevel = null;
-  errors = null;
-  xhrError = null;
-  isLoading = false;
-  subTitle = null;
+  @tracked result = null;
+  @tracked errorLevel = null;
+  @tracked errors = null;
+  @tracked xhrError = null;
+  @tracked isLoading = false;
+  @tracked subTitle = null;
 
   @alias('errors') messages;
   @equal('writerType', 'json') isJson;
@@ -147,7 +148,7 @@ export default class MdTranslateComponent extends Component {
 
   _clearResult() {
     this.result = null;
-    this.subtitle = null;
+    this.subTitle = null;
     this.errors = null;
     this.xhrError = null;
   }
@@ -278,8 +279,9 @@ export default class MdTranslateComponent extends Component {
 
   @action
   goToSettings() {
-    // This action should be handled by the parent route/controller
-    // We'll send the action up the component hierarchy
-    this.sendAction('goToSettings');
+    // Invoke the closure action passed from the parent route
+    if (this.onGoToSettings && typeof this.onGoToSettings === 'function') {
+      this.onGoToSettings();
+    }
   }
 }

--- a/app/pods/components/md-translate/template.hbs
+++ b/app/pods/components/md-translate/template.hbs
@@ -9,7 +9,8 @@
         <form {{action "translate" on="submit"}}>
             <div class="card-block">
                 {{input/md-select label="Choose Format"
-                  value=this.writer
+                  model=this
+                  path="writer"
                   valuePath="value"
                   namePath="name"
                   objectArray=this.writerOptions
@@ -85,7 +86,7 @@
         <h4 class="text-{{this.errorClass}}">{{this.errorSubTitle}}</h4>
         <ul class="list-group">
           {{#each this.messages as |message|}}
-            {{#with (compute (action "errorClass") message.[0]) as |errorClass|}}
+            {{#with (compute (action "errorClassAction") message.[0]) as |errorClass|}}
               <li class="list-group-item">
                 <div class="">
                   <h4 class="list-group-item-heading">

--- a/app/pods/export/route.js
+++ b/app/pods/export/route.js
@@ -130,6 +130,10 @@ export default class ExportRoute extends Route.extend(ScrollTo) {
         if (item.type === 'settings' && item.attributes?.publishOptions) {
           let publishOptions = item.attributes.publishOptions;
 
+          if (!Array.isArray(publishOptions)) {
+            publishOptions = [];
+          }
+
           // Migrate legacy 'catalog' field to new 'publisher' field for each publish option
           publishOptions = publishOptions.map((option) => {
             if (option.catalog && !option.publisher) {

--- a/app/pods/record/show/translate/route.js
+++ b/app/pods/record/show/translate/route.js
@@ -4,8 +4,13 @@ import { inject as service } from '@ember/service';
 
 export default class TranslateRoute extends Route {
   @service router;
+
+  model() {
+    return this.modelFor('record.show');
+  }
+
   setupController(controller, model) {
-    this._super(controller, model);
+    super.setupController(controller, model);
 
     controller.setProperties({
       writer: controller.writer || null,
@@ -13,6 +18,7 @@ export default class TranslateRoute extends Route {
       showAllTags: controller.showAllTags || false,
     });
   }
+  @action
   goToSettings() {
     this.router.transitionTo('settings.main');
   }

--- a/app/pods/record/show/translate/template.hbs
+++ b/app/pods/record/show/translate/template.hbs
@@ -3,11 +3,10 @@
       <h3>Translate Record</h3>
         {{md-translate
           model=this.model
-          store=this.store
           writer=this.writer
           forceValid=this.forceValid
           showAllTags=this.showAllTags
-          goToSettings=(route-action "goToSettings")
+          onGoToSettings=(route-action "goToSettings")
         }}
     </div>
 </div>

--- a/app/pods/settings/main/route.js
+++ b/app/pods/settings/main/route.js
@@ -12,12 +12,8 @@ export default class MainRoute extends Route {
     return this.settings.get('data');
   }
 
+  @action
   setScrollTo(scrollTo) {
     this.controller.set('scrollTo', scrollTo || '');
-  }
-
-  @action
-  setScrollToAction(scrollTo) {
-    this.setScrollTo(scrollTo);
   }
 }

--- a/app/pods/settings/main/template.hbs
+++ b/app/pods/settings/main/template.hbs
@@ -66,7 +66,7 @@
         message="<h4 class=\"text-danger\"><span class=\"fa fa-exclamation-circle\"></span> <strong>Are you
             sure?</strong></h4> Clicking <strong class=\"text-danger\">Confirm</strong> will delete ALL records in
         your browser cache. Have you made a backup?"
-        confirm=(route-action "clearLocalStorage")
+        confirmAction=(route-action "clearLocalStorage")
         showCancel=true
         cancelType="primary"
         showConfirm=true

--- a/app/pods/settings/route.js
+++ b/app/pods/settings/route.js
@@ -46,6 +46,7 @@ export default class SettingsRoute extends Route {
     controller.set('links', links);
   }
 
+  @action
   clearLocalStorage() {
     let data = this.settings.data.serialize({ includeId: true });
 
@@ -66,14 +67,17 @@ export default class SettingsRoute extends Route {
     //this.transitionTo('application');
   }
 
+  @action
   save() {
     this.settings.data.save();
   }
 
+  @action
   catalogs() {
     return this.get('publish.catalogs');
   }
 
+  @action
   deriveItisProxyUrl() {
     let model = this.modelFor('settings.main');
     const mdTranslatorAPI = model.get('mdTranslatorAPI');
@@ -87,6 +91,7 @@ export default class SettingsRoute extends Route {
     }
   }
 
+  @action
   getPublishOptions(catalogName) {
     let model = this.modelFor('settings.main');
     let publishOptions = model.get('publishOptions') || [];

--- a/app/services/patch.js
+++ b/app/services/patch.js
@@ -64,7 +64,7 @@ export default Service.extend({
                     set(
                       src,
                       'description',
-                      get(src, 'description', get(src, 'value'))
+                      get(src, 'description') || get(src, 'value')
                     );
                     set(src, 'value', null);
                   });

--- a/lib/ember-json-tree/addon/components/tree-view.js
+++ b/lib/ember-json-tree/addon/components/tree-view.js
@@ -12,7 +12,7 @@ export default Component.extend({
   init() {
     this._super(...arguments);
 
-    this.set('tree', get(this, 'tree', this));
+    this.set('tree', get(this, 'tree') || this);
     this.sortKeys = ['label'];
   },
 

--- a/lib/ember-leaflet-table/addon/components/feature-form.js
+++ b/lib/ember-leaflet-table/addon/components/feature-form.js
@@ -11,8 +11,8 @@ export default Component.extend({
 
     let item = this.get('model');
 
-    set(item, 'properties', get(item, 'properties', {}));
-    set(item, 'properties.name', get(item, 'properties.name', 'Feature'));
+    set(item, 'properties', get(item, 'properties') || {});
+    set(item, 'properties.name', get(item, 'properties.name') || 'Feature');
   },
 
   layout,

--- a/lib/ember-leaflet-table/addon/components/feature-table.js
+++ b/lib/ember-leaflet-table/addon/components/feature-table.js
@@ -37,9 +37,9 @@ export default class FeatureTable extends Table {
 
     data.forEach((item, idx) => {
 
-      set(item, 'properties', get(item, 'properties', {}));
+      set(item, 'properties', get(item, 'properties') || {});
       set(item, 'properties.name', get(item,
-        'properties.name', 'Feature' + (idx + 1)));
+        'properties.name') || 'Feature' + (idx + 1));
     });
   }
 }

--- a/lib/mdeditor-sciencebase/addon/components/sb-publisher.js
+++ b/lib/mdeditor-sciencebase/addon/components/sb-publisher.js
@@ -13,7 +13,8 @@ export default Component.extend({
 
   init() {
     this._super(...arguments);
-    let publishOptions = this.get('settings.data.publishOptions') || [];
+    let rawOptions = this.get('settings.data.publishOptions');
+    let publishOptions = Array.isArray(rawOptions) ? rawOptions : [];
     // Support both legacy 'catalog' field and new 'publisher' field
     let settings =
       publishOptions.find(
@@ -35,7 +36,7 @@ export default Component.extend({
         hideCheck: true,
         isRoot: true,
         nodeClass: 'sb-tree-root',
-        sbId: get(settings, 'sb-defaultParent', get(config, 'defaultParent')),
+        sbId: get(settings, 'sb-defaultParent') || get(config, 'defaultParent'),
         config: config,
         willDestroy() {
           let children = this.get('children');
@@ -118,7 +119,8 @@ export default Component.extend({
 
   createNode(rec) {
     let config = this.get('config');
-    let publishOptions = this.get('settings.data.publishOptions') || [];
+    let rawOpts = this.get('settings.data.publishOptions');
+    let publishOptions = Array.isArray(rawOpts) ? rawOpts : [];
     // Support both legacy 'catalog' field and new 'publisher' field
     let settings =
       publishOptions.find(
@@ -126,11 +128,7 @@ export default Component.extend({
           option.catalog === 'ScienceBase' || option.publisher === 'ScienceBase'
       ) || {};
     setProperties(config, {
-      defaultParent: get(
-        settings,
-        'sb-defaultParent',
-        get(config, 'defaultParent')
-      ),
+      defaultParent: get(settings, 'sb-defaultParent') || get(config, 'defaultParent'),
       defaultCommunity: get(settings, 'sb-defaultCommunity'),
       defaultOrganization: get(settings, 'sb-defaultOrganization'),
     });

--- a/lib/mdeditor-sciencebase/addon/components/sb-tree.js
+++ b/lib/mdeditor-sciencebase/addon/components/sb-tree.js
@@ -85,7 +85,7 @@ export default Tree.extend({
             ),
         })
       );
-      set(record, path + '.identifier', get(record, path + 'identifier', arr));
+      set(record, path + '.identifier', get(record, path + 'identifier') || arr);
       record.get('parentIds').pushObject(newParentId);
     }
 

--- a/lib/mdeditor-sciencebase/addon/utils/sb-tree-node.js
+++ b/lib/mdeditor-sciencebase/addon/utils/sb-tree-node.js
@@ -165,7 +165,7 @@ export default EmberObject.extend({
     let path = 'json.metadata.resourceInfo.citation.identifier';
     let arr = A();
 
-    set(record, path, get(record, path, arr));
+    set(record, path, get(record, path) || arr);
 
     get(record, path).pushObject({
       authority: {
@@ -193,12 +193,12 @@ export default EmberObject.extend({
     set(
       record,
       path,
-      get(record, path, {
+      get(record, path) || {
         title: 'Parent Metadata',
-      })
+      }
     );
 
-    set(record, idPath, get(record, idPath, arr));
+    set(record, idPath, get(record, idPath) || arr);
 
     get(record, idPath).pushObject({
       authority: {
@@ -263,11 +263,9 @@ export default EmberObject.extend({
     let record = this;
     let sbId = record.get('sbId');
     let publishOptions = record.get('settings');
-    let rootURI = get(
-      publishOptions,
-      'publisherEndpoint',
-      get(publishOptions, 'sb-publishEndpoint', this.get('config.rootURI'))
-    );
+    let rootURI = get(publishOptions, 'publisherEndpoint') ||
+      get(publishOptions, 'sb-publishEndpoint') ||
+      this.get('config.rootURI');
     let defaultParent = this.get('config.defaultParent');
     let url =
       record.get('type') === 'project'
@@ -333,17 +331,17 @@ export default EmberObject.extend({
             set(
               idObj,
               'authority',
-              get(idObj, 'authority', {
+              get(idObj, 'authority') || {
                 date: [],
                 title: 'ScienceBase',
-              })
+              }
             );
             set(
               idObj,
               'authority.title',
-              get(idObj, 'authority.title', 'ScienceBase')
+              get(idObj, 'authority.title') || 'ScienceBase'
             );
-            set(idObj, 'authority.date', get(idObj, 'authority.date', []));
+            set(idObj, 'authority.date', get(idObj, 'authority.date') || []);
 
             get(idObj, 'authority.date').pushObject({
               date: moment().toISOString(),

--- a/package.json
+++ b/package.json
@@ -180,7 +180,7 @@
       "lib/mdeditor-sciencebase"
     ]
   },
-  "packageManager": "yarn@4.3.1",
+  "packageManager": "yarn@4.12.0",
   "dependencies": {
     "velocity-animate": "^1.5.2"
   }


### PR DESCRIPTION
# Note:  This PR is a branch of #803 and should not be merged until #803  has been merged.

Closes #799 
## Problem                                                                                                                  
                                                                                                      
### Two distinct bugs were causing rendering crashes:                                                                        
                                                                                                      
  1. `publishOptions.find` is not a function — `publishOptions` was a non-array `truthy` value (e.g., an object). The || []
  fallback only catches `falsy` values, so `.find()` was called on a non-array.
  2. Get must be called with two arguments — Ember's `get(obj, key)` was being called with 3 arguments `get(obj, key, default)` as if it supported a default value parameter. Modern Ember does not support this.

### Files Changed

  Fix 1: `Array.isArray` guard for `publishOptions`
  File: `app/pods/components/control/md-couch-login/component.js`
  Change: `publishOptions || [] → Array.isArray(raw) ? raw : []`
  ────────────────────────────────────────
  File: `lib/mdeditor-sciencebase/addon/components/sb-publisher.js (init)`
  Change: Same fix
  ────────────────────────────────────────
  File: `lib/mdeditor-sciencebase/addon/components/sb-publisher.js (createNode)`
  Change: Same fix
  ────────────────────────────────────────
  File: `app/pods/export/route.js`
  Change: Added `Array.isArray` guard before `.map()`
  Fix 2: 3-argument `get()` → 2-argument `get() || default`
  File: `lib/mdeditor-sciencebase/addon/components/sb-publisher.js`
  Lines: 2 calls
  Change: `get(settings, 'sb-defaultParent', fallback)` → `get(...) ||` fallback
  ────────────────────────────────────────
  File: `lib/mdeditor-sciencebase/addon/utils/sb-tree-node.js`
  Lines: 5 calls
  Change: Default values for identifiers, parent metadata, publish endpoints, authority objects
  ────────────────────────────────────────
  File: `lib/mdeditor-sciencebase/addon/components/sb-tree.js`
  Lines: 1 call
  Change: Identifier array default
  ────────────────────────────────────────
  File: `lib/ember-json-tree/addon/components/tree-view.js`
  Lines: 1 call
  Change: `get(this, 'tree', this)` → `get(this, 'tree') || this`
  ────────────────────────────────────────
  File: `lib/ember-leaflet-table/addon/components/feature-form.js`
  Lines: 2 calls
  Change: Properties/name defaults
  ────────────────────────────────────────
  File: `lib/ember-leaflet-table/addon/components/feature-table.js`
  Lines: 2 calls
  Change: Properties/name defaults
  ────────────────────────────────────────
  File: `app/services/patch.js`
  Lines: 1 call
  Change: Description fallback to value
  Total: 4 files for the `Array.isArray` fix, 7 files for the get() fix (14 individual call sites patched).
