### PR TITLE
BUG: Fix profiles not being applied to resource

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -15,6 +15,7 @@ import {
   get,
   //set
 } from '@ember/object';
+import { inject as service } from '@ember/service';
 import {
   isNone
 } from '@ember/utils';
@@ -51,6 +52,8 @@ Route.reopen({
 });
 //for profiles
 Component.reopen({
+  profile: service('custom-profile'),
+
   init() {
     this._super(...arguments);
 

--- a/app/instance-initializers/profile.js
+++ b/app/instance-initializers/profile.js
@@ -1,8 +1,7 @@
 export function initialize(/* appInstance */) {
-  // Implicit injections are deprecated in Ember 3.x+
-  // Components that need the custom-profile service should use:
-  //   @service('custom-profile') profile;
-  // See: https://deprecations.emberjs.com/v3.x#toc_implicit-injections
+  // The custom-profile service is injected into all components via
+  // Component.reopen() in app/app.js (replaces the deprecated
+  // appInstance.inject('component', 'profile', 'service:custom-profile')).
 }
 
 export default {

--- a/app/pods/components/control/md-edit-table/component.js
+++ b/app/pods/components/control/md-edit-table/component.js
@@ -25,8 +25,7 @@ export default class MdEditTableComponent extends MdRecordTableComponent {
    * @extends md-record-table
    */
 
-  // classNames = ['md-edit-table'];
-  tagName = '';
+  classNames = ['md-edit-table'];
   spotlightRow = true;
 
   /**
@@ -57,16 +56,14 @@ export default class MdEditTableComponent extends MdRecordTableComponent {
       title: 'Edit',
       type: 'success',
       icon: 'pencil',
-      // action: this.actions.editRow,
-      action: "editRow",
+      action: "handleEditRow",
       target: this
     }, {
       title: 'Delete',
       type: 'danger',
       icon: 'times',
       confirm: true,
-      //action: this.actions.deleteRow,
-      action: "deleteRow",
+      action: "handleDeleteRow",
       target: this
     }]
 
@@ -91,13 +88,17 @@ export default class MdEditTableComponent extends MdRecordTableComponent {
   }
 
   @action
-  editRow(col, index, record, evt){
+  handleEditRow(col, index, record, evt){
     evt.stopPropagation();
-    this.editRowMethod(index, record);
+    if (typeof this.editRow === 'function') {
+      this.editRow(col, index, record, evt);
+    } else {
+      this.editRowMethod(index, record);
+    }
   }
 
   @action
-  deleteRow(col, index, record){
+  handleDeleteRow(col, index, record){
     record.destroyRecord();
   }
 }


### PR DESCRIPTION
## Summary                                                                                                                
                                                                                                                       
  Profile switching was completely broken after the Ember 4 upgrade — selecting a different profile (e.g., "Project"
  instead of "Full") had no effect on displayed fields or panels. Additionally, the scroll-spy sidebar navigation did not
  update when profiles changed, and the settings profile page crashed on render.

### Bug 1: Profile switching does not update displayed fields/panels

  Root cause: The implicit service injection (`appInstance.inject('component', 'profile', 'service:custom-profile')`) was
  removed during the Ember 4 upgrade because it's deprecated, but no replacement was added. The global `Component.reopen in app.js` relies on this.profile being available on all components — without it, the `_profileHidden` computed property always returned false, making all fields permanently visible.

  Files changed:
  - `app/app.js` — Added `profile: service('custom-profile')` to `Component.reopen()`, restoring the service injection for all
  components using the non-deprecated `service()` descriptor pattern
  - `app/instance-initializers/profile.js` — Updated comment to document the new injection location

### Bug 2: Settings profile page crashes with "Cannot set property editRow"

  Root cause: `md-edit-table` defined editRow as an `@action` (read-only getter), but parent templates pass `editRow=(action 'editProfile')` as an argument. Ember 4 can't set the argument on a read-only getter. Additionally, `tagName = '' (tagless)` was incompatible with the inherited click handler from ember-models-table.

  Files changed:
  - `app/pods/components/control/md-edit-table/component.js` — Renamed `@action editRow` to` @action handleEditRow` which delegates to the passed `editRow` callback if present; renamed `@action deleteRow` to `@action handleDeleteRow`; removed `tagName = ''` and re-enabled classNames

  Enhancement: Scroll-spy sidebar syncs with profile changes

  Problem: When switching profiles, hidden panels disappeared from the main content but their entries persisted in the
  scroll-spy sidebar navigation.

  Files changed:
  - `app/pods/components/control/md-scroll-spy/component.js` — Changed links from a plain getter to an observable property; added an observer on profile.active that re-reads visible data-spy elements from the DOM after render completes;
extracted DOM reading logic into `_computeLinks()` method

closes #793 
closes #795 
