### PR TITLE
FIX: Add path separator for ScienceBase Publisher Endpoint URL construction

### DIFF
--- a/lib/mdeditor-sciencebase/addon/utils/sb-tree-node.js
+++ b/lib/mdeditor-sciencebase/addon/utils/sb-tree-node.js
@@ -266,11 +266,13 @@ export default EmberObject.extend({
     let rootURI = get(publishOptions, 'publisherEndpoint') ||
       get(publishOptions, 'sb-publishEndpoint') ||
       this.get('config.rootURI');
+    // Remove trailing slash if present to ensure consistent path construction
+    rootURI = rootURI.replace(/\/$/, '');
     let defaultParent = this.get('config.defaultParent');
     let url =
       record.get('type') === 'project'
-        ? rootURI + 'project'
-        : rootURI + 'product';
+        ? rootURI + '/project'
+        : rootURI + '/product';
     let urlPut = sbId ? '/' + sbId : '';
 
     let data = {


### PR DESCRIPTION
closes #816 

## Problem
When publishing to ScienceBase, the Publisher Endpoint URL was concatenated directly with path segments without a separator, causing malformed URLs. For example, entering https://ifwaz-samps.fws.doi.net would result in https://ifwaz-samps.fws.doi.netproject/... instead of https://ifwaz-samps.fws.doi.net/project/....

### Solution
Updated the URL construction logic in `sb-tree-node.js:266-276` to: 

1. Strip any trailing slash from the endpoint URL to ensure consistency 
2. Add a forward slash separator when concatenating with path segm ents (/project or /product)

### Testing

1. Go to Settings → ScienceBase
2. Enter Publisher Endpoint without trailing slash: https://ifwaz-samps.fws.doi.net
3. Publish a record
4. Verify in Network tab that URL is correctly formatted: https://ifwaz-samps.fws.doi.net/project/...
