### PR TITLE
Fix taxonomy collection blank screen

### DIFF
--- a/app/pods/record/show/edit/taxonomy/collection/index/route.js
+++ b/app/pods/record/show/edit/taxonomy/collection/index/route.js
@@ -9,8 +9,8 @@ export default class IndexRoute extends Route.extend(ScrollTo) {
   @service router;
 
   setupController() {
-    // Call _super for default behavior
-    this._super(...arguments);
+    // Call super for default behavior
+    super.setupController(...arguments);
 
     this.controller.set('parentModel', this.modelFor('record.show.edit'));
     this.controller.set(

--- a/app/pods/record/show/edit/taxonomy/collection/system/index/route.js
+++ b/app/pods/record/show/edit/taxonomy/collection/system/index/route.js
@@ -7,8 +7,8 @@ export default class IndexRoute extends Route.extend(ScrollTo) {
   @service router;
 
   setupController(controller) {
-    // Call _super for default behavior
-    this._super(...arguments);
+    // Call super for default behavior
+    super.setupController(...arguments);
 
     let systemId = this.paramsFor(
       'record.show.edit.taxonomy.collection.system'

--- a/app/pods/record/show/edit/taxonomy/index/route.js
+++ b/app/pods/record/show/edit/taxonomy/index/route.js
@@ -31,7 +31,13 @@ export default class IndexRoute extends Route.extend(ScrollTo) {
     let taxa = this.currentRouteModel().get(
       'json.metadata.resourceInfo.taxonomy'
     );
-    let collection = EmberObject.create({});
+    let collection = EmberObject.create({
+      taxonomicSystem: [],
+      identificationReference: [],
+      observer: [],
+      voucher: [],
+      taxonomicClassification: [],
+    });
 
     // once(this, () => {
 

--- a/app/pods/settings/route.js
+++ b/app/pods/settings/route.js
@@ -23,6 +23,10 @@ export default class SettingsRoute extends Route {
   @service
   profile;
 
+  beforeModel() {
+    return this.settings._setupPromise;
+  }
+
   setupController(controller, model) {
     super.setupController(controller, model);
 
@@ -80,6 +84,7 @@ export default class SettingsRoute extends Route {
   @action
   deriveItisProxyUrl() {
     let model = this.modelFor('settings.main');
+    if (!model || typeof model.get !== 'function') { return; }
     const mdTranslatorAPI = model.get('mdTranslatorAPI');
     if (mdTranslatorAPI) {
       // Extract the base URL by removing the API path
@@ -94,6 +99,7 @@ export default class SettingsRoute extends Route {
   @action
   getPublishOptions(catalogName) {
     let model = this.modelFor('settings.main');
+    if (!model || typeof model.get !== 'function') { return {}; }
     let publishOptions = model.get('publishOptions') || [];
 
     // Ensure publishOptions is always an array

--- a/app/services/settings.js
+++ b/app/services/settings.js
@@ -11,7 +11,8 @@ const {
 
 export default Service.extend({
   store: service(),
-  data: 'null',
+  data: null,
+  _setupPromise: null,
 
   init() {
     this._super(...arguments);
@@ -20,13 +21,11 @@ export default Service.extend({
   },
   setup() {
     let me = this;
-    let settings;
     let store = this.store;
 
-    store.findAll('setting').then(function (s) {
+    let promise = store.findAll('setting').then(function (s) {
       let rec = s.get('firstObject');
-
-      settings = rec ? rec : store.createRecord('setting');
+      let settings = rec ? rec : store.createRecord('setting');
 
       if (settings.get('lastVersion') !== version) {
         settings.set('showSplash', environment !== 'test');
@@ -44,7 +43,12 @@ export default Service.extend({
       if (!(me.get('isDestroyed') || me.get('isDestroying'))) {
         me.set('data', settings);
       }
+
+      return settings;
     });
+
+    this.set('_setupPromise', promise);
+    return promise;
   },
   repositoryTemplate: EmberObject.extend({
     init() {


### PR DESCRIPTION
closes #813 
closes #812 

# Summary
Fixes an issue where navigating to a taxonomy collection (new or existing) resulted in a blank screen and a browser error: Assertion Failed: Cannot call get with 'taxonomicClassification' on an undefined object.

### Root Cause

Two taxonomy route files (collection/index/route.js and collection/system/index/route.js) were using `this._super(...arguments)` inside setupController. In native ES6 class syntax, this._super is not wired up by Ember's
CoreObject for lifecycle hooks — it only works in classic class init(). As a result, Ember never ran the default
setupController behavior, leaving controller.model as undefined. Any subsequent access to the model's properties (e.g.
taxonomicClassification) triggered the assertion failure.

  Additionally, the addCollection action was creating a bare `EmberObject.create({})` with no properties, meaning a newly
  added collection had no arrays initialized for required fields.

Changes

- `taxonomy/collection/index/route.js` — replaced `this._super(...arguments)` with `super.setupController(...arguments)`
- `taxonomy/collection/system/index/route.js` — same fix
- `taxonomy/index/route.js` — initialize new collection objects with all required arrays (taxonomicSystem,
identificationReference, observer, voucher, taxonomicClassification) so components don't receive undefined properties