### PR TITLE
FIX: Fix checkbox selection and "Delete Selected" button functionality

### DIFF
--- a/app/models/base.js
+++ b/app/models/base.js
@@ -100,11 +100,9 @@ const Base = Model.extend({
       true
     );
 
-    // if the currentHash is undefined, the record is either new or hasn't had the
-    // hash calculated yet
-    if (this.currentHash === undefined) {
-      this.set('currentHash', newHash);
-    }
+    // Always set the currentHash to ensure imported records get proper hash
+    this.set('currentHash', newHash);
+    this.set('jsonSnapshot', JSON.parse(this.serialize().data.attributes.json));
   },
 
   wasUpdated() {

--- a/app/pods/components/control/md-record-table/buttons/filter/component.js
+++ b/app/pods/components/control/md-record-table/buttons/filter/component.js
@@ -1,4 +1,5 @@
 import { inject as service } from '@ember/service';
+import { computed } from '@ember/object';
 import classic from 'ember-classic-decorator';
 import Component from '@ember/component';
 import { action } from '@ember/object';
@@ -8,28 +9,24 @@ import { once } from '@ember/runloop';
 export default class FilterComponent extends Component {
   @service flashMessages;
 
+  // Use computed property to track selectedItems changes
+  @computed('selectedItems.[]')
   get showButton() {
-    return this.selectedItems?.length > 1;
-  }
-
-  deleteSelected(records) {
-    records.forEach(rec => {
-      rec.destroyRecord()
-        .then((rec) => {
-          rec.unloadRecord();
-          once(() => {
-            records.removeObject(rec);
-            this.flashMessages
-              .danger(
-                `Deleted ${rec.constructor.modelName} "${rec.get('title')}".`
-              );
-          });
-        });
-    });
+    return this.selectedItems?.length >= 1;
   }
 
   @action
-  deleteSelectedAction(records) {
-    this.deleteSelected(records);
+  deleteSelected(records) {
+    records.forEach((rec) => {
+      rec.destroyRecord().then((rec) => {
+        rec.unloadRecord();
+        once(() => {
+          records.removeObject(rec);
+          this.flashMessages.danger(
+            `Deleted ${rec.constructor.modelName} "${rec.get('title')}".`
+          );
+        });
+      });
+    });
   }
 }

--- a/app/pods/components/control/md-record-table/buttons/filter/template.hbs
+++ b/app/pods/components/control/md-record-table/buttons/filter/template.hbs
@@ -1,5 +1,5 @@
 {{#if this.showButton}}
-  <Control::MdButtonConfirm class="btn btn-danger btn-block" @onConfirm={{action "deleteSelected" this.selectedItems}}>
+  <Control::MdButtonConfirm class="btn btn-danger btn-block" @onConfirm={{fn this.deleteSelected this.selectedItems}}>
     <span class="fa fa-times"></span> Delete Selected
   </Control::MdButtonConfirm>
 {{/if}}

--- a/app/pods/components/control/md-record-table/component.js
+++ b/app/pods/components/control/md-record-table/component.js
@@ -1,8 +1,7 @@
-import { computed, get, defineProperty } from '@ember/object';
+import { computed, get, defineProperty, observer } from '@ember/object';
+import { run } from '@ember/runloop';
 import Table from 'mdeditor/pods/components/md-models-table/component';
-import {
-  warn
-} from '@ember/debug';
+import { warn } from '@ember/debug';
 import { isArray, A } from '@ember/array';
 
 export default Table.extend({
@@ -27,31 +26,61 @@ export default Table.extend({
    * @extends models-table
    */
   init() {
-
     this.dataColumns = this.dataColumns || [];
     this.filteringIgnoreCase = this.filteringIgnoreCase || true;
     this.multipleSelect = this.multipleSelect || true;
 
-    defineProperty(this, 'columns', computed('dataColumns', 'checkColumn',
-      function () {
+    defineProperty(
+      this,
+      'columns',
+      computed('dataColumns', 'checkColumn', function () {
         let chk = this.checkColumn;
         let action = this.actionsColumn;
         let cols = A().concat(this.dataColumns);
 
-        if(chk) {
+        if (chk) {
           cols = [chk].concat(cols);
         }
 
-        if(action) {
+        if (action) {
           cols.push(action);
         }
 
         return cols;
-      }));
+      })
+    );
 
     this._super(...arguments);
   },
   classNames: ['md-record-table'],
+
+  /**
+   * Observer to sync parent's selectedItems array with our selectProperty
+   */
+  syncSelectedItemsObserver: observer('selectedItems.[]', function () {
+    // Whenever selectedItems changes, sync the selectProperty on all records
+    run.next(() => {
+      let prop = this.selectProperty;
+      let data = this.data;
+
+      // Get parent's actual selectedItems (not our override)
+      let parentSelectedItems = this.get('selectedItems');
+
+      if (!prop || !data) {
+        return;
+      }
+
+      // Sync all records so their selectProperty matches being in parent's selectedItems
+      data.forEach((item) => {
+        const isSelected =
+          parentSelectedItems && parentSelectedItems.includes(item);
+        const currentValue = item.get(prop);
+        if (currentValue !== isSelected) {
+          item.set(prop, isSelected);
+        }
+      });
+    });
+  }),
 
   /**
    * Property name used to identify selected records. Should begin with underscore.
@@ -105,13 +134,12 @@ export default Table.extend({
    * @required
    */
   checkColumn: computed(function () {
-
     return {
       component: 'components/md-models-table/components/check',
       disableFiltering: true,
       mayBeHidden: false,
       componentForSortCell: 'components/md-models-table/components/check-all',
-      className: 'text-center'
+      className: 'text-center',
     };
   }),
 
@@ -143,34 +171,19 @@ export default Table.extend({
     return {
       title: 'Actions',
       className: 'md-actions-column',
-      component: all ?
-        'control/md-record-table/buttons' :
-        'control/md-record-table/buttons/show',
+      component: all
+        ? 'control/md-record-table/buttons'
+        : 'control/md-record-table/buttons/show',
       disableFiltering: !all,
-      componentForFilterCell: all ?
-        'control/md-record-table/buttons/filter' : null,
-      showSlider: this.showSlider
+      componentForFilterCell: all
+        ? 'control/md-record-table/buttons/filter'
+        : null,
+      showSlider: this.showSlider,
     };
   }),
 
-  selectedItems: computed({
-    get() {
-      let prop = this.selectProperty;
-
-      return this.data
-        .filterBy(prop)
-        .toArray();
-
-    },
-    set(k, v) {
-      if(!isArray(v)) {
-        warn('`selectedItems` must be an array.', false, {
-          id: '#emt-selectedItems-array'
-        });
-      }
-      return A(v);
-    }
-  }),
+  // Remove our custom selectedItems - let parent handle it
+  // selectedItems is managed by the parent ember-models-table component
 
   /**
    * Callback on row selection.
@@ -184,43 +197,4 @@ export default Table.extend({
   select(rec, index, selected) {
     return selected;
   },
-
-  actions: {
-    clickOnRow(idx, rec) {
-      this._super(...arguments);
-
-      let prop = this.selectProperty;
-      let sel = this.selectedItems;
-
-      rec.toggleProperty(prop);
-      this.select(rec, idx, sel);
-    },
-
-    toggleAllSelection() {
-      //this._super(...arguments);
-      let selectedItems = this.selectedItems;
-      let data = this.data;
-      const allSelectedBefore = get(selectedItems, 'length') === get(data,
-        'length');
-      this.selectedItems
-        .clear();
-
-      if(!allSelectedBefore) {
-        this.selectedItems
-          .pushObjects(data.toArray());
-      }
-      this.userInteractionObserver();
-
-      let selected = this.selectedItems;
-      let prop = this.selectProperty;
-      //let data = get(this, 'data');
-
-      if(get(selected, 'length')) {
-        selected.setEach(prop, true);
-      } else {
-        data.setEach(prop, false);
-      }
-      this.select(null, null, selected);
-    }
-  }
 });

--- a/app/pods/components/md-models-table/components/check-all/component.js
+++ b/app/pods/components/md-models-table/components/check-all/component.js
@@ -1,10 +1,15 @@
 import Component from '@ember/component';
 import classic from 'ember-classic-decorator';
+import { action } from '@ember/object';
 
 @classic
 export default class CheckAllComponent extends Component {
-  actions = {
-    toggleAllSelection() {
+  // toggleAllSelection is passed in from parent
+  toggleAllSelection = null;
+
+  @action
+  doToggleAllSelection() {
+    if (this.toggleAllSelection) {
       this.toggleAllSelection();
     }
   }

--- a/app/pods/components/md-models-table/components/check-all/template.hbs
+++ b/app/pods/components/md-models-table/components/check-all/template.hbs
@@ -1,4 +1,4 @@
-<span {{action "toggleAllSelection"}} role="button" class="center-block
-{{if (is-equal this.selectedItems.length this.data.length)
-  this.themeInstance.select-all-rows this.themeInstance.deselect-all-rows}}">
+<span {{on "click" this.doToggleAllSelection}} role="button" class="center-block md-checkbox-all">
+  <i class={{if (is-equal this.selectedItems.length this.data.length)
+    this.themeInstance.selectAllRowsIcon this.themeInstance.deselectAllRowsIcon}}></i>
 </span>

--- a/app/pods/components/md-models-table/components/check/component.js
+++ b/app/pods/components/md-models-table/components/check/component.js
@@ -1,14 +1,21 @@
 import Component from '@ember/component';
 import classic from 'ember-classic-decorator';
+import { action } from '@ember/object';
+import { tryInvoke } from '@ember/utils';
 
 @classic
 export default class CheckComponent extends Component {
   attributeBindings = ['aria-checked:isSelected'];
 
-  actions = {
-    clickOnRow(index, record, event) {
+  // clickOnRow is passed in from parent
+  clickOnRow = null;
+
+  @action
+  doClickOnRow(index, record, event) {
+    if (this.clickOnRow) {
       this.clickOnRow(index, record);
-      event.stopPropagation();
     }
+    tryInvoke(event, 'stopPropagation');
+    return false;
   }
 }

--- a/app/pods/components/md-models-table/components/check/template.hbs
+++ b/app/pods/components/md-models-table/components/check/template.hbs
@@ -1,1 +1,3 @@
-<span class={{if this.isSelected this.themeInstance.select-row this.themeInstance.deselect-row}} onclick={{action "clickOnRow" this.index this.record}} role="checkbox"></span>
+<span {{on "click" (fn this.doClickOnRow this.index this.record)}} role="checkbox" class="md-checkbox-cell">
+  <i class={{if this.isSelected this.themeInstance.selectRowIcon this.themeInstance.deselectRowIcon}}></i>
+</span>

--- a/app/pods/import/route.js
+++ b/app/pods/import/route.js
@@ -5,6 +5,7 @@ import { assign } from '@ember/polyfills';
 import Route from '@ember/routing/route';
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
+import { later, scheduleOnce } from '@ember/runloop';
 import Base from 'ember-local-storage/adapters/base';
 import ScrollTo from 'mdeditor/mixins/scroll-to';
 import { JsonDefault as Contact } from 'mdeditor/models/contact';
@@ -544,6 +545,34 @@ export default class ImportRoute extends Route.extend(ScrollTo) {
         json: false,
       })
       .then(() => {
+        // Wait for all records to be fully loaded and their observers to fire
+        // before resetting the hash to prevent dirty state
+        later(() => {
+          ['record', 'contact', 'dictionary'].forEach((modelName) => {
+            store.peekAll(modelName).forEach((record) => {
+              if (
+                record &&
+                record.isLoaded &&
+                !record.isNew &&
+                !record.isDeleted
+              ) {
+                try {
+                  let json = JSON.parse(
+                    record.serialize().data.attributes.json
+                  );
+                  record.setCurrentHash(json);
+                  record.set('jsonSnapshot', json);
+                  // Notify property change to force hasDirtyHash recomputation
+                  record.notifyPropertyChange('currentHash');
+                } catch (e) {
+                  // Skip records that can't be serialized
+                  console.warn('Could not reset hash for record:', e);
+                }
+              }
+            });
+          });
+        }, 100);
+
         this.flashMessages.success(
           `Imported data. Records were
               ${

--- a/app/styles/_table.scss
+++ b/app/styles/_table.scss
@@ -169,6 +169,11 @@
     background-color: lighten($brand-info, 40);
     cursor: pointer;
   }
+
+  .md-checkbox-cell,
+  .md-checkbox-all {
+    cursor: pointer;
+  }
 }
 //Wider Responsive tables
 


### PR DESCRIPTION
## Summary

### Description
Fix checkbox selection and "Delete Selected" button functionality after Ember 3.28.6 upgrade, and resolve false dirty state indicators on imported records

This PR addresses multiple issues related to the Ember 3.28.6 upgrade:

Checkbox Selection System: Restores row selection functionality in table views (records, contacts, dictionaries, import) that was broken after upgrading to Ember 3.28.6. The checkboxes now properly toggle selection state and trigger the display of the "Delete Selected" button.

Import Dirty State: Fixes issue where cleanly imported records incorrectly showed the red "This record has been modified! Click to save." indicator immediately after import.

closes #797 
closes #791 

