### PR TITLE
FIX: Missing panels from export route

### DIFF
--- a/app/pods/export/route.js
+++ b/app/pods/export/route.js
@@ -53,7 +53,7 @@ export default class ExportRoute extends Route.extend(ScrollTo) {
     });
   }
   setupController(controller, model) {
-    this._super(controller, model);
+    super.setupController(controller, model);
 
     defineProperty(
       this.controller,


### PR DESCRIPTION
## Summary

The Export page rendered a blank screen and the "Include Settings" toggle had no effect, while "Export All" continued to
  function normally.

### Root Cause

Export Route.setupController called `this._super(controller, model)` in a native ES6 class (no @classic decorator). In
native class syntax, `this._super` is not wired up by Ember's CoreObject for lifecycle hooks — calling it throws silently,
so the default setupController behavior never ran. As a result:

- `controller.model` was never set, leaving every `this.model.*` reference in the template undefined → blank screen
- The `hasSelected` and `hasSelectedRecords` computed properties were never defined on the controller via `defineProperty` → Export Selected buttons always disabled
- `this.model.settings._selected` was `undefined._selected` → the Include Settings toggle couldn't read or write its value

"Export All" was unaffected because it calls `this.store.exportData(modelTypes)` directly with no dependency on
`controller.model`.

Change

- `app/pods/export/route.js` — replaced `this._super(controller, model)` with `super.setupController(controller, model)`

closes #794 