### PR TITLE
FIX: Help panel not displaying when question mark icon is clicked                                                         

### DIFF
--- a/app/pods/components/layout/md-nav-sidebar/component.js
+++ b/app/pods/components/layout/md-nav-sidebar/component.js
@@ -1,6 +1,7 @@
 import Component from '@ember/component';
 import classic from 'ember-classic-decorator';
 import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
 import config from 'mdeditor/config/environment';
 
 @classic
@@ -8,7 +9,7 @@ export default class MdNavSidebarComponent extends Component {
   classNames = ['md-sidebar-wrapper'];
   classNameBindings = ['showHelp:help'];
 
-  showHelp = false;
+  @tracked showHelp = false;
 
   get prerelease() {
     let version = this.version;

--- a/app/pods/components/layout/md-nav-sidebar/template.hbs
+++ b/app/pods/components/layout/md-nav-sidebar/template.hbs
@@ -3,7 +3,7 @@
       <a class="sidebar-brand-link" href="#" {{action "toggleSidebar"}}>md<span class="md-icon-mdeditor"></span>ditor</a><span class="md-app-version {{this.prerelease}}">v{{this.version}}</span>
       <a class="md-btn-help pull-right" href="#" {{action "toggleHelp"}}>{{fa-icon (if this.showHelp "list" "question-circle")}}</a>
     </li>
-    {{#liquid-if this.showHelp use="fade" enableGrowth=false}}
+    {{#if this.showHelp}}
       {{md-help}}
     {{else}}
     <li id="md-sidebar-lists">
@@ -61,5 +61,5 @@
         {{/each}}
       </div>
     </li>
-    {{/liquid-if}}
+    {{/if}}
   </ul>

--- a/app/pods/components/layout/md-nav-sidebar/template.hbs
+++ b/app/pods/components/layout/md-nav-sidebar/template.hbs
@@ -3,8 +3,8 @@
       <a class="sidebar-brand-link" href="#" {{action "toggleSidebar"}}>md<span class="md-icon-mdeditor"></span>ditor</a><span class="md-app-version {{this.prerelease}}">v{{this.version}}</span>
       <a class="md-btn-help pull-right" href="#" {{action "toggleHelp"}}>{{fa-icon (if this.showHelp "list" "question-circle")}}</a>
     </li>
-    {{#if this.showHelp}}
-      {{md-help}}
+    {{#liquid-if predicate=this.showHelp class="help-selected"}}
+      <MdHelp/>
     {{else}}
     <li id="md-sidebar-lists">
       <div class="panel-group">
@@ -61,5 +61,5 @@
         {{/each}}
       </div>
     </li>
-    {{/if}}
+    {{/liquid-if}}
   </ul>

--- a/app/transitions.js
+++ b/app/transitions.js
@@ -152,7 +152,7 @@ export default function () {
     this.toRoute('dictionary.show.edit'),
     this.fromRoute('dictionary.show.index'),
     this.use('toLeft'),
-    this.reverse('toRight'),
+    this.reverse('toRight')
     //this.debug()
   );
   this.transition(
@@ -228,11 +228,11 @@ export default function () {
     this.includingInitialRender(),
     this.toValue(true),
     this.use('toRight', {
-      duration: 250
+      duration: 250,
     }),
     this.reverse('toLeft', {
-      duration: 250
-    })//,
+      duration: 250,
+    }) //,
     //this.debug()
   );
   this.transition(
@@ -240,11 +240,15 @@ export default function () {
     this.includingInitialRender(),
     this.toValue(true),
     this.use('toLeft', {
-      duration: 250
+      duration: 250,
     }),
     this.reverse('toRight', {
-      duration: 250
-    })//,
+      duration: 250,
+    }) //,
     //this.debug()
+  );
+  this.transition(
+    this.hasClass('help-selected'),
+    this.use('toLeft', { duration: 300 })
   );
 }


### PR DESCRIPTION
 # Summary                                                                                                                          

Clicking the ? icon in the sidebar header had no visible effect — the help panel never appeared.

closes #790 
                                                                                                                           
## Root Cause                                                

  Two compounding issues:

  1. Missing `@tracked` — `showHelp` was a plain class field (showHelp = false) with no reactivity decorator. In Ember 4,
  templates are rendered by the Glimmer engine which only tracks changes through `@tracked`. Classic KVO (this.set()) fires classic observers but does not invalidate Glimmer's tracking tags, so the template never re-rendered when `showHelp`
changed. Adding `@tracked` makes the property visible to Glimmer's tracking system.
  2. `{{#liquid-if}}` incompatibility — liquid-fire 0.37.1 predates Ember Octane's `@tracked` system. Its liquid-if component
  wires up its condition via classic template bindings that are not aware of `@tracked` updates in Ember 4's Glimmer
  renderer. Even with `@tracked` on `showHelp`, liquid-if may not reliably switch branches. Replacing it with a standard
  `{{#if}}` removes that dependency.

  ## Changes

  - `layout/md-nav-sidebar/component.js` — added `@tracked` to `showHelp`; switched `toggleHelp` to direct assignment
  (this.showHelp = !this.showHelp) which is idiomatic with `@tracked`
  - `layout/md-nav-sidebar/template.hbs` — replaced `{{#liquid-if}}` / `{{/liquid-if}}` with `{{#if}}` / `{{/if}}`

  The fade transition on the help panel is removed as a side effect, but the panel now correctly appears and disappears
  when the ? icon is clicked.