### PR TITLE
FIX: `mdModal` Crash

### DIFF
--- a/app/pods/components/control/md-modal/component.js
+++ b/app/pods/components/control/md-modal/component.js
@@ -76,41 +76,30 @@ export default class MdModalComponent extends Component {
    *
    * @method closeModal
    */
+  @action
   closeModal() {
     this.toggleProperty('isShowing');
   }
 
   /**
    * Confirm action callback
-   * @method confirm
+   * @property confirm
    */
-  confirm() {
+  confirm = () => {
     if (this.confirmAction) {
       this.confirmAction();
     }
     this.closeModal();
-  }
+  };
 
   /**
    * Cancel action callback
    *
-   * @method cancel
+   * @property cancel
    */
-  cancel() {
+  cancel = () => {
     this.closeModal();
-  }
+  };
 
-  actions = {
-    closeModal() {
-      this.closeModal();
-    },
 
-    confirm() {
-      this.confirm();
-    },
-
-    cancel() {
-      this.cancel();
-    }
-  }
 }


### PR DESCRIPTION
## Summary
Fix` md-modal` crash — "Cannot set property confirm which has only a getter". Opening any screen that renders control/md-modal caused an immediate render failure.

closes #823
                                                                                                                           
### Root Cause                                                

The component had a mixed pattern that broke during the Ember 4 migration:

  - The template used the modern `{{on "click" this.confirm}}` and `{{on "click" this.cancel}}` modifiers, which require
  functions bound to this. Without that binding, accessing `this.confirmAction` inside `confirm()` would throw an assertion
  error.
  - The obvious fix — adding `@action` to `confirm()` and `cancel()` — introduced a second, fatal problem: `@action` defines properties as getter-only descriptors on the prototype. The component has two call patterns across the app: some callers (settings) pass `confirmAction=` and rely on the internal method, while others (application, import, taxonomy) pass
`confirm=` or `cancel=` directly as handlers to override the defaults. When Ember's `CoreObject.create()` tried to apply those passed-in attributes to the new instance, it attempted to write to the getter-only slots and crashed.
  - The actions hash (actions = { confirm() {...} }) compounded the issue with the same name collision against @action's getter descriptors.

  ### Changes (app/pods/components/control/md-modal/component.js)

  - confirm and cancel converted from methods to arrow function class fields — they are bound to this at construction (safe
   for {{on}}), and are regular writable instance properties (safe for external callers to override via confirm= / cancel=)
  - closeModal decorated with `@action` — it is never passed from outside and needs to remain accessible to the string-based `{{action "closeModal"}}` in the template
  - actions hash removed — it conflicted with the `@action` getter descriptor on `closeModal` and was otherwise redundant