### PR TITLE
FIX: Taxa Bug

### DIFF
--- a/app/pods/components/control/md-button-confirm/template.hbs
+++ b/app/pods/components/control/md-button-confirm/template.hbs
@@ -1,11 +1,19 @@
-{{#if this.isShowingConfirm}}
+{{!-- {{#if this.isShowingConfirm}}
   <i class="fa fa-question"></i> Confirm
 {{else}}
   {{yield}}
-{{/if}}
+{{/if}} --}}
+
+{{#liquid-if predicate=this.isShowingConfirm class='button-confirm'}}
+<i class="fa fa-question"></i> Confirm
+{{else}}
+  {{yield}}
+{{/liquid-if}}
 
 {{#if this.isShowingConfirm}}
   {{#if this.tooltip}}
     {{ember-tooltip tooltipClass=(concat "ember-tooltip md-tooltip " this.tipClass) text=this.tooltip side=this.tipSide}}
   {{/if}}
 {{/if}}
+
+

--- a/app/pods/components/control/md-button/component.js
+++ b/app/pods/components/control/md-button/component.js
@@ -1,5 +1,6 @@
 import Component from '@ember/component';
 import classic from 'ember-classic-decorator';
+import { computed } from '@ember/object';
 
 @classic
 export default class MdButtonComponent extends Component {
@@ -73,6 +74,7 @@ export default class MdButtonComponent extends Component {
   * @category computed
   * @requires text
   */
+  @computed('text')
   get responsive() {
     return this.text.length > 12 || this.text.indexOf(' ') > 0;
   }

--- a/app/pods/components/object/md-taxonomy/classification/taxon/component.js
+++ b/app/pods/components/object/md-taxonomy/classification/taxon/component.js
@@ -2,6 +2,7 @@ import Component from '@ember/component';
 import classic from 'ember-classic-decorator';
 import { htmlSafe } from '@ember/string';
 import { action, get } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
 import { alias } from '@ember/object/computed';
 import { inject as service } from '@ember/service';
 import { validator, buildValidations } from 'ember-cp-validations';
@@ -30,7 +31,8 @@ export default class MdTaxonomyClassificationTaxonComponent extends Component.ex
   tagName = 'li';
   classNames = ['list-group-item', 'md-taxon'];
   classNameBindings = ['collapse'];
-  isEditing = false;
+  @tracked isEditing = false;
+  @tracked collapse = false;
   preview = false;
 
   @alias('model.taxonomicLevel') taxonomicLevel;
@@ -83,8 +85,7 @@ export default class MdTaxonomyClassificationTaxonComponent extends Component.ex
 
     this.isEditing = true;
 
-    // this.spotlight.setTarget('editor-' + this.elementId, this.stopEditing,this);
-    this.spotlight.setTarget(id, this.stopEditing, this);
+    this.spotlight.setTarget(id, null, null);
 
     scrollIntoView(document.getElementById(editor), {
       behavior: 'smooth',
@@ -92,16 +93,14 @@ export default class MdTaxonomyClassificationTaxonComponent extends Component.ex
     });
   }
 
-  stopEditing() {
-    this.isEditing = false;
-  }
-
+  @action
   deleteTaxa(taxa) {
     let parent = this.top || get(this.parentItem, 'model.subClassification');
 
     parent.removeObject(taxa);
   }
 
+  @action
   addChild() {
     this.model.subClassification.pushObject({
       commonName: [],
@@ -117,11 +116,6 @@ export default class MdTaxonomyClassificationTaxonComponent extends Component.ex
   }
 
   @action
-  deleteTaxaAction(taxa) {
-    this.deleteTaxa(taxa);
-  }
-
-  @action
   toggleEditing() {
     if(this.isEditing) {
       this.spotlight.close();
@@ -129,10 +123,5 @@ export default class MdTaxonomyClassificationTaxonComponent extends Component.ex
       return;
     }
     this.startEditing();
-  }
-
-  @action
-  addChildAction() {
-    this.addChild();
   }
 }

--- a/app/pods/components/object/md-taxonomy/classification/taxon/component.js
+++ b/app/pods/components/object/md-taxonomy/classification/taxon/component.js
@@ -1,7 +1,7 @@
 import Component from '@ember/component';
 import classic from 'ember-classic-decorator';
 import { htmlSafe } from '@ember/string';
-import { action, get } from '@ember/object';
+import { action, computed, set } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 import { alias } from '@ember/object/computed';
 import { inject as service } from '@ember/service';
@@ -41,8 +41,7 @@ export default class MdTaxonomyClassificationTaxonComponent extends Component.ex
 
   get level() {
     let parent = this.parentItem;
-
-    return parent ? parent.get('level') + 1 : 0;
+    return parent ? parent.level + 1 : 0;
   }
 
   get padding() {
@@ -50,7 +49,8 @@ export default class MdTaxonomyClassificationTaxonComponent extends Component.ex
 
     return htmlSafe('padding-left: ' + pad + 'rem;');
   }
-
+  
+  @computed('model.subClassification.length')
   get collapsible() {
     return this.model?.subClassification?.length;
   }
@@ -65,8 +65,8 @@ export default class MdTaxonomyClassificationTaxonComponent extends Component.ex
     super.didReceiveAttrs(...arguments);
 
     once(this, function () {
-      this.model.commonName = this.model.commonName ?? [];
-      this.model.subClassification = this.model.subClassification ?? [];
+      set(this.model, 'commonName', this.model.commonName || []);
+      set(this.model, 'subClassification', this.model.subClassification || []);
     });
   }
 
@@ -95,18 +95,29 @@ export default class MdTaxonomyClassificationTaxonComponent extends Component.ex
 
   @action
   deleteTaxa(taxa) {
-    let parent = this.top || get(this.parentItem, 'model.subClassification');
+    let parent = this.top || this.parentItem?.model?.subClassification;
+    if (!parent) return;
 
-    parent.removeObject(taxa);
+    let next = (parent || []).filter((item) => item !== taxa);
+
+    if (this.top) {
+      set(this, 'top', next);
+    } else if (this.parentItem && this.parentItem.model) {
+      set(this.parentItem.model, 'subClassification', next);
+    }
   }
 
   @action
   addChild() {
-    this.model.subClassification.pushObject({
+    let children = this.model.subClassification || [];
+    let child = {
       commonName: [],
       subClassification: [],
       _edit: true
-    });
+    };
+
+    let next = [...children, child];
+    set(this.model, 'subClassification', next);
   }
 
   @action

--- a/app/pods/components/object/md-taxonomy/classification/taxon/template.hbs
+++ b/app/pods/components/object/md-taxonomy/classification/taxon/template.hbs
@@ -49,7 +49,7 @@
 </div>
 <div id={{concat "editor-" this.elementId}}>
 
-  {{#liquid-if this.isEditing}}
+  {{#if this.isEditing}}
     <div class="md-taxon-form">
       <form class="card form" {{action "toggleEditing" on="submit"}}>
         <div class="card-block row form-inline">
@@ -102,12 +102,12 @@
       </form>
     </div>
 
-  {{/liquid-if}}
+  {{/if}}
 </div>
 </div>
 
   {{#with this.collapsible}}
-    {{#liquid-unless this.collapse class="list-group-item"}}
+    {{#unless this.collapse}}
       {{object/md-taxonomy/classification model=this.model.subClassification parentItem=this dragging=this.dragging preview=this.preview profilePath=this.profilePath}}
-    {{/liquid-unless}}
+    {{/unless}}
   {{/with}}

--- a/app/pods/record/show/edit/taxonomy/collection/itis/route.js
+++ b/app/pods/record/show/edit/taxonomy/collection/itis/route.js
@@ -14,8 +14,8 @@ export default class ItisRoute extends Route {
     };
   }
   setupController() {
-    // Call _super for default behavior
-    this._super(...arguments);
+    // Call super for default behavior
+    super.setupController(...arguments);
 
     this.controller.set('parentModel', this.modelFor('record.show.edit'));
     this.controller.set(

--- a/app/pods/record/show/edit/taxonomy/collection/itis/template.hbs
+++ b/app/pods/record/show/edit/taxonomy/collection/itis/template.hbs
@@ -1,9 +1,9 @@
 <h4 class="section-header">
-  Add Taxa from ITIS<small> Taxonomy Collection #{{collectionId}}</small>
-  {{control/md-status model=parentModel}}
+  Add Taxa from ITIS<small> Taxonomy Collection #{{this.collectionId}}</small>
+  {{control/md-status model=this.parentModel}}
 </h4>
 
-{{control/md-itis taxonomy=model}}
+{{control/md-itis taxonomy=this.model}}
 
 {{to-elsewhere
   named="md-subbar-extra"

--- a/app/transitions.js
+++ b/app/transitions.js
@@ -152,7 +152,7 @@ export default function () {
     this.toRoute('dictionary.show.edit'),
     this.fromRoute('dictionary.show.index'),
     this.use('toLeft'),
-    this.reverse('toRight'),
+    this.reverse('toRight')
     //this.debug()
   );
   this.transition(
@@ -228,11 +228,11 @@ export default function () {
     this.includingInitialRender(),
     this.toValue(true),
     this.use('toRight', {
-      duration: 250
+      duration: 250,
     }),
     this.reverse('toLeft', {
-      duration: 250
-    })//,
+      duration: 250,
+    }) //,
     //this.debug()
   );
   this.transition(
@@ -240,11 +240,16 @@ export default function () {
     this.includingInitialRender(),
     this.toValue(true),
     this.use('toLeft', {
-      duration: 250
+      duration: 250,
     }),
     this.reverse('toRight', {
-      duration: 250
-    })//,
+      duration: 250,
+    }) //,
     //this.debug()
+  );
+
+  this.transition(
+    this.hasClass('button-confirm'),
+    this.use('toDown', { duration: 250 })
   );
 }

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "@ember/optional-features": "^1.3.0",
     "@ember/test-helpers": "^5.4.1",
     "@glimmer/component": "^1.1.2",
+    "@glimmer/tracking": "^1.1.2",
     "@mapbox/togeojson": "^0.16.2",
     "Leaflet.vector-markers": "^0.0.6",
     "ajv": "^6.12.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2070,7 +2070,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@glimmer/tracking@npm:^1.0.4":
+"@glimmer/tracking@npm:^1.0.4, @glimmer/tracking@npm:^1.1.2":
   version: 1.1.2
   resolution: "@glimmer/tracking@npm:1.1.2"
   dependencies:
@@ -14800,6 +14800,7 @@ __metadata:
     "@ember/optional-features": "npm:^1.3.0"
     "@ember/test-helpers": "npm:^5.4.1"
     "@glimmer/component": "npm:^1.1.2"
+    "@glimmer/tracking": "npm:^1.1.2"
     "@mapbox/togeojson": "npm:^0.16.2"
     Leaflet.vector-markers: "npm:^0.0.6"
     ajv: "npm:^6.12.6"


### PR DESCRIPTION
## Summary  

 Fixed Add Child behavior for taxonomy classification taxon so it works correctly on Ember 3.28.6, creating a new child taxon and opening the edit modal as expected.                                                 

close #822 

  - ITIS route blank screen: `setupController` was using `this._super()` (invalid in native class syntax in Ember 4) — replaced
   with `super.setupController(...arguments)` so the controller's model is correctly set before the template renders
  - ITIS template bare property refs: `model`, `parentModel`, and `collectionId` were referenced without this. prefix — updated to `this.model`, `this.parentModel`, `this.collectionId` (required in Ember 4 with this-property-fallback removed)
  - Taxon edit form not rendering / collapsing incorrectly: `isEditing` and collapse were plain class fields with no
  reactivity — added `@tracked` so the Glimmer rendering engine observes changes
  - `liquid-if` / `liquid-unless` incompatibility: Replaced `{{#liquid-if}}` and `{{#liquid-unless}}` with `{{#if}}` and `{{#unless}}`
  — liquid-fire 0.37.1 does not reliably observe `@tracked` values in Ember 4
  - `deleteTaxa` and `addChild` actions not found: Both methods were missing the `@action` decorator — added `@action` and removed the redundant wrapper action methods (deleteTaxaAction, addChildAction)
  - Taxa edit form immediately closing: `startEditing()` was passing `stopEditing` as the spotlight close callback; since
  ember-modal-dialog uses document-level click handlers, any click on form inputs (which live outside the modal container
  DOM) triggered stopEditing → `isEditing = false` → form collapse. Fixed by passing null as the spotlight close callback;
  form now closes only via the explicit OK button / form submit
  - `md-button` responsive getter conflict: Native JS getter get `responsive()` creates a getter-only descriptor that
  `CoreObject.create()` cannot override when `responsive=false` is passed as an attribute — converted to `@computed('text')` getter which creates a writable Ember computed property descriptor
 - Normalized subClassification and commonName initialization in taxon by ensuring they are always arrays and using `set(this.model, ...)` so tracked contexts (templates/computeds) update without assertions.

### Updated child add/delete logic to be Ember‑3.28‑friendly by:
- Replacing in-place `EmberArray-style` mutations with creating new arrays and using set (e.g., set(this.model, 'subClassification', next)).
- Adjusting `deleteTaxa` to compute a filtered copy and update either the top array or the parent’s `model.subClassification` via set.
- Made collapsibility reactive by changing collapsible to a classic computed depending on `model.subClassification.length`, ensuring the nested classification list appears/disappears when children are added or removed.