### PR TITLE
BUG: Fix imported schema download error

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -5,6 +5,12 @@
  * @category docs
  */
 
+// @apidevtools/json-schema-ref-parser references Buffer as a global in browser builds.
+// Provide a minimal stub so isBuffer() checks pass without error.
+if (typeof Buffer === 'undefined') {
+  window.Buffer = { isBuffer: () => false };
+}
+
 import Route from '@ember/routing/route';
 import Component from '@ember/component';
 import Application from '@ember/application';

--- a/app/services/schemas.js
+++ b/app/services/schemas.js
@@ -36,9 +36,23 @@ export default class SchemasService extends Service {
   fetchSchemas = task({ drop: true }, async (url) => {
     await timeout(1000);
 
-    const parser = new $RefParser(); // Use $RefParser directly here
+    const parser = new $RefParser();
 
-    return await parser.resolve(url).then($refs => {
+    // Override the default HTTP resolver to use fetch() and return text.
+    // The default resolver uses Buffer.from() which is a Node.js global not
+    // available in the browser. Returning a string bypasses all Buffer usage.
+    const browserHttpResolver = {
+      read(file) {
+        return fetch(file.url).then(res => {
+          if (!res.ok) {
+            throw new Error(`HTTP ${res.status}: ${file.url}`);
+          }
+          return res.text();
+        });
+      }
+    };
+
+    return await parser.resolve(url, { resolve: { http: browserHttpResolver } }).then($refs => {
       let paths = $refs.paths();
       let values = parser.$refs.values();
 


### PR DESCRIPTION
closes #842 
 ## Problem

Clicking "Save Schema" in Settings → Validation threw Error downloading `<url>`, buffer is not defined. The schema appeared to load, but the error flash always fired.

## Root Cause

`@apidevtools/json-schema-ref-parser` v11 is designed as a Node.js library. Its HTTP resolver (resolvers/http.js) fetches the remote schema with `fetch()` but then converts the response via `Buffer.from(arrayBuffer)` and `Buffer.alloc(0)` — `Node.js` globals that don't exist in the browser. Webpack 5 removed automatic Node.js polyfills, so these throw `ReferenceError:` Buffer is not defined, which `json-schema-ref-parser` catches and re-throws as Error downloading <url>.

The same global is also referenced in three parsers (json.js, yaml.js, binary.js) and `parse.js` via `Buffer.isBuffer()`.

A `webpack.ProvidePlugin` approach was attempted first but failed because app.js goes through the Ember module loader (loader.js), not the webpack pipeline — so import { Buffer } from 'buffer' was never resolvable at runtime.

## Changes

`app/app.js`

Added an inline guard that sets `window.Buffer = { isBuffer: () => false }` when Buffer is not already defined. This is a plain JS expression with no imports, so it runs unconditionally before any app code. All `Buffer.isBuffer()` calls in the parsers return false, causing them to treat data as a string — which is correct since we're dealing with JSON.

`app/services/schemas.js`
Provided a custom http resolver to parser.resolve() via the options second argument. The custom resolver uses the native browser `fetch()` API and returns `res.text()` directly. Because the options are deep-merged with defaults, only the read method is replaced — canRead, order, and other defaults remain unchanged. This bypasses `Buffer.from()` and `Buffer.alloc()` in the default resolver entirely.

Together, these changes cover all Buffer references in the library without requiring any `npm polyfill` package or `webpack` configuration.