### PR TITLE
refactor: convert classic @computed to @tracked getters on 5 components

### DIFF
--- a/app/pods/components/control/md-button/component.js
+++ b/app/pods/components/control/md-button/component.js
@@ -1,6 +1,6 @@
 import Component from '@ember/component';
 import classic from 'ember-classic-decorator';
-import { computed } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
 
 @classic
 export default class MdButtonComponent extends Component {
@@ -76,9 +76,12 @@ export default class MdButtonComponent extends Component {
    * @category computed
    * @requires text
    */
-  @computed('text')
+  @tracked _responsive;
   get responsive() {
-    return this.text.length > 12 || this.text.indexOf(' ') > 0;
+    return this._responsive ?? (this.text.length > 12 || this.text.indexOf(' ') > 0);
+  }
+  set responsive(value) {
+    this._responsive = value;
   }
 
   click(event) {

--- a/app/pods/components/control/md-record-table/buttons/filter/component.js
+++ b/app/pods/components/control/md-record-table/buttons/filter/component.js
@@ -1,5 +1,4 @@
 import { inject as service } from '@ember/service';
-import { computed } from '@ember/object';
 import classic from 'ember-classic-decorator';
 import Component from '@ember/component';
 import { once } from '@ember/runloop';
@@ -8,7 +7,6 @@ import { once } from '@ember/runloop';
 export default class FilterComponent extends Component {
   @service flashMessages;
 
-  @computed('selectedItems.[]')
   get showButton() {
     return this.selectedItems?.length >= 1;
   }

--- a/app/pods/components/layout/md-object-container/component.js
+++ b/app/pods/components/layout/md-object-container/component.js
@@ -1,6 +1,6 @@
 import Component from '@ember/component';
 import classic from 'ember-classic-decorator';
-import { computed } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
 
 @classic
 export default class MdObjectContainerComponent extends Component {
@@ -35,9 +35,12 @@ export default class MdObjectContainerComponent extends Component {
   */
   collapseProperty = true;
 
-  @computed('collapsible', 'collapseProperty')
+  @tracked _isCollapsible;
   get isCollapsible() {
-    return this.collapsible && this.collapseProperty;
+    return this._isCollapsible ?? (this.collapsible && this.collapseProperty);
+  }
+  set isCollapsible(value) {
+    this._isCollapsible = value;
   }
 
   get dataSpy() {

--- a/app/pods/components/md-translate/component.js
+++ b/app/pods/components/md-translate/component.js
@@ -1,7 +1,7 @@
 import { alias, equal, or } from '@ember/object/computed';
 import Component from '@ember/component';
 import classic from 'ember-classic-decorator';
-import { action, computed } from '@ember/object';
+import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 import { inject as service } from '@ember/service';
 import { Promise } from 'rsvp';
@@ -46,7 +46,7 @@ export default class MdTranslateComponent extends Component {
    */
   forceValid = false;
 
-  writer = null;
+  @tracked writer = null;
   @tracked result = null;
   @tracked errorLevel = null;
   @tracked errors = null;
@@ -126,9 +126,12 @@ export default class MdTranslateComponent extends Component {
     return null;
   }
 
-  @computed('writer', 'writerOptions')
+  @tracked _writeObj;
   get writeObj() {
-    return this.writerOptions.findBy('value', this.writer);
+    return this._writeObj ?? this.writerOptions.findBy('value', this.writer);
+  }
+  set writeObj(value) {
+    this._writeObj = value;
   }
 
   get writerType() {

--- a/app/pods/components/object/md-keyword-list/component.js
+++ b/app/pods/components/object/md-keyword-list/component.js
@@ -1,6 +1,7 @@
 import classic from 'ember-classic-decorator';
 import Component from '@ember/component';
-import { action, computed } from '@ember/object';
+import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
 
 /**
  * @module mdeditor
@@ -9,9 +10,15 @@ import { action, computed } from '@ember/object';
 
 @classic
 export default class MdKeywordListComponent extends Component {
-  @computed('model.thesaurus.identifier.0.identifier')
+  @tracked _readOnly;
   get readOnly() {
-    return this.model?.thesaurus?.identifier?.[0]?.identifier !== 'custom';
+    return (
+      this._readOnly ??
+      (this.model?.thesaurus?.identifier?.[0]?.identifier !== 'custom')
+    );
+  }
+  set readOnly(value) {
+    this._readOnly = value;
   }
 
   @action


### PR DESCRIPTION
 ### What
Migrates classic `@computed` properties to native `@tracked`-backed getters on five classic components, as part of the Octane migration.

| Component | Property | Treatment |
| :--- | :---: | ---: |
| control/md-button | responsive | getter + setter (external callers bind @responsive) |
| control/md-record-table/buttons/filter | showButton | plain getter (no external set) |
| layout/md-object-container | isCollapsible | getter + setter (external isCollapsible= bindings) |
| md-translate | writeObj, writer | getter + setter / @tracked field |
| object/md-keyword-list | readOnly | getter + setter (test two-way binds) |

### Why
Removes `@computed` decorators in favor of native getters with `@tracked` backing fields, moving these classic components closer to Octane idioms while preserving existing behavior.

### Approach notes
- Setters retained where callers two-way bind the property. Templates and tests assign these props directly (@responsive={{true}}, isCollapsible=true, writeObj=writer, readOnly=false), so the setter preserves the implicit two-way set contract the classic @computed getter provided. The ?? fallback keeps the derived default until a value is explicitly set.
- `showButton` uses a plain getter — nothing sets it, so no backing field/setter needed.
- These remain @classic / @ember/component for now. The @tracked _x backing fields are transitional; when these components later convert to Glimmer, the setters get removed and callers move to data-down/actions-up. Out of scope here.