### PR TITLE
REFACTOR: Removed classic export extend, lifecycle patterns, and runtinme regressions

### DIFF
--- a/app/pods/components/control/md-fiscalyear/component.js
+++ b/app/pods/components/control/md-fiscalyear/component.js
@@ -2,44 +2,40 @@ import { computed } from '@ember/object';
 import Select from 'mdeditor/pods/components/input/md-select/component';
 import layout from 'mdeditor/pods/components/input/md-select/template';
 import moment from 'moment';
-import {
-  inject as service
-} from '@ember/service';
+import { inject as service } from '@ember/service';
+import { not } from '@ember/object/computed';
 
 export default Select.extend({
   layout,
   settings: service('settings'),
   classNames: ['md-fiscalyear'],
-  init() {
-    this._super(...arguments);
-    this.set('label', 'Pick Fiscal Year');
-    this.set('placeholder', 'Pick a Fiscal Year');
-  },
+  label: 'Pick Fiscal Year',
+  placeholder: 'Pick a Fiscal Year',
   objectArray: computed(function () {
     return Array.apply(0, Array(12)).map(function (element, index) {
       return {
-        year: index + (moment().year() - 10)
+        year: index + (moment().year() - 10),
       };
     });
   }),
-  label: 'Pick Fiscal Year',
   valuePath: 'year',
   namePath: 'year',
   tooltip: false,
   searchEnabled: true,
-  placeholder: 'Pick a Fiscal Year',
   create: true,
-  disabled: computed('settings.data.fiscalStartMonth', function() {
-    return !this.get('settings.data.fiscalStartMonth');
+  disabled: computed('settings.data.fiscalStartMonth', function () {
+    return not(this.get('settings.data.fiscalStartMonth'));
   }),
   change() {
-    let val = this.value;
-    let month = parseInt(this.get(
-      'settings.data.fiscalStartMonth'), 10) - 1;
-    let dt = month <= 6 ? moment(val, 'YYYY') : moment(val, 'YYYY').subtract(1, 'year');
-    let start = dt.month(month).startOf('month');
-    let end = start.clone().add(11, 'months').endOf('month');
-    let context = this.context;
+    const val = this.value;
+    const month = parseInt(this.get('settings.data.fiscalStartMonth'), 10) - 1;
+    const dt =
+      month <= 6
+        ? moment(val, 'YYYY')
+        : moment(val, 'YYYY').subtract(1, 'year');
+    const start = dt.month(month).startOf('month');
+    const end = start.clone().add(11, 'months').endOf('month');
+    const context = this.context;
 
     if (context) {
       context.set('start', start.toISOString());
@@ -47,5 +43,5 @@ export default Select.extend({
     }
 
     this.set('value', null);
-  }
+  },
 });

--- a/app/pods/components/control/md-fiscalyear/component.js
+++ b/app/pods/components/control/md-fiscalyear/component.js
@@ -1,34 +1,38 @@
-import { computed } from '@ember/object';
+import { computed, get } from '@ember/object';
+import { not } from '@ember/object/computed';
+import { inject as service } from '@ember/service';
+import classic from 'ember-classic-decorator';
 import Select from 'mdeditor/pods/components/input/md-select/component';
 import layout from 'mdeditor/pods/components/input/md-select/template';
 import moment from 'moment';
-import { inject as service } from '@ember/service';
-import { not } from '@ember/object/computed';
 
-export default Select.extend({
-  layout,
-  settings: service('settings'),
-  classNames: ['md-fiscalyear'],
-  label: 'Pick Fiscal Year',
-  placeholder: 'Pick a Fiscal Year',
-  objectArray: computed(function () {
-    return Array.apply(0, Array(12)).map(function (element, index) {
-      return {
-        year: index + (moment().year() - 10),
-      };
-    });
-  }),
-  valuePath: 'year',
-  namePath: 'year',
-  tooltip: false,
-  searchEnabled: true,
-  create: true,
-  disabled: computed('settings.data.fiscalStartMonth', function () {
-    return not(this.get('settings.data.fiscalStartMonth'));
-  }),
+/**
+ * Fiscal year picker built on md-select.
+ *
+ * @class md-fiscalyear
+ * @extends md-select
+ */
+@classic
+class MdFiscalyearComponent extends Select {
+  layout = layout;
+
+  label = 'Pick Fiscal Year';
+
+  placeholder = 'Pick a Fiscal Year';
+
+  valuePath = 'year';
+
+  namePath = 'year';
+
+  tooltip = false;
+
+  searchEnabled = true;
+
+  create = true;
+
   change() {
     const val = this.value;
-    const month = parseInt(this.get('settings.data.fiscalStartMonth'), 10) - 1;
+    const month = parseInt(get(this, 'settings.data.fiscalStartMonth'), 10) - 1;
     const dt =
       month <= 6
         ? moment(val, 'YYYY')
@@ -43,5 +47,28 @@ export default Select.extend({
     }
 
     this.set('value', null);
-  },
+  }
+}
+
+MdFiscalyearComponent.reopen({
+  settings: service('settings'),
+
+  objectArray: computed(function () {
+    return Array.apply(0, Array(12)).map(function (element, index) {
+      return {
+        year: index + (moment().year() - 10),
+      };
+    });
+  }),
+
+  disabled: computed('settings.data.fiscalStartMonth', function () {
+    return not(this.get('settings.data.fiscalStartMonth'));
+  }),
 });
+
+MdFiscalyearComponent.prototype.classNames = [
+  ...Select.prototype.classNames,
+  'md-fiscalyear',
+];
+
+export default MdFiscalyearComponent;

--- a/app/pods/components/control/md-indicator/related/component.js
+++ b/app/pods/components/control/md-indicator/related/component.js
@@ -1,123 +1,52 @@
-import Indicator from 'mdeditor/pods/components/control/md-indicator/component';
 import { get, computed } from '@ember/object';
-import { bool, map } from '@ember/object/computed';
+import { bool } from '@ember/object/computed';
+import classic from 'ember-classic-decorator';
+import Indicator from 'mdeditor/pods/components/control/md-indicator/component';
 
-export default Indicator.extend({
-  /**
-   * @module mdeditor
-   * @submodule components-control
-   */
+/**
+ * @module mdeditor
+ * @submodule components-control
+ */
 
-  /**
-   * Icon that display a popover with information on a related object.
-   *
-   * ```handlebars
-   * \{{control/md-indicator/related
-   *   model=model
-   *   route=true
-   *   icon="sticky-note"
-   *   note="${foo} has an associated domain ${bar}"
-   *   route="dictionary.show.edit.entity"
-   *   values=values
-   *   parent=dictionary
-   *   relatedId="domainId"
-   *   relatedIdLocal="domainId"
-   *   path="domain"
-   *   title="Related Indicator Test"
-   *   linkText="Go to Domain"
-   *   type="warning"
-   *   popperContainer="body"
-   * }}
-   * ```
-   *
-   * @class md-indicator--related
-   * @extends md-indicator
-   * @constructor
-   */
-
+/**
+ * Icon that displays a popover with information on a related object.
+ *
+ * ```handlebars
+ * {{control/md-indicator/related
+ *   model=model
+ *   icon="sticky-note"
+ *   note="${foo} has an associated domain ${bar}"
+ *   route="dictionary.show.edit.entity"
+ *   values=values
+ *   parent=dictionary
+ *   relatedId="domainId"
+ *   path="domain"
+ *   title="Related Indicator Test"
+ *   linkText="Go to Domain"
+ *   type="warning"
+ *   popperContainer="body"
+ * }}
+ * ```
+ *
+ * @class md-indicator--related
+ * @extends md-indicator
+ */
+@classic
+class MdIndicatorRelatedComponent extends Indicator {
   init() {
-    this._super(...arguments);
+    super.init(...arguments);
+
     this.type = this.type || 'info';
     this.linkText = this.linkText || 'Open Related';
     this.classNames = ['md-indicator-related', `md-${this.type}`].concat(
       this.classNames
     );
-  },
+  }
+}
 
+MdIndicatorRelatedComponent.reopen({
   isVisible: bool('related'),
-  /**
-   * The string value of the "link-to" route argument.
-   *
-   * @property route
-   * @type {String}
-   */
 
-  /**
-   * The object to use as the data model for the "local" object.
-   *
-   * @property model
-   * @type {Object}
-   * @required
-   */
-
-  /**
-   * The string value used to render text to tooltip button.
-   *
-   * @property linkText
-   * @type {String}
-   * @required
-   */
-
-  /**
-   * The parent dictionary object for this attribute used to lookup references.
-   *
-   * @property parent
-   * @type {Object}
-   * @required
-   */
-
-  /**
-   * The string value property used in the related computed property.
-   *
-   * @property path
-   * @type {String}
-   * @required
-   */
-
-  /**
-   * The name of the property used to lookup the related object. This property will
-   * be used for both the local and related objects if relatedIdLocal is not
-   * specified.
-   *
-   * @property relatedId
-   * @type {String}
-   * @required
-   */
-
-  /**
-   * The string value property used in the "local" object to find the related
-   * object.
-   *
-   * @property relatedIdLocal
-   * @type {String}
-   * @required
-   */
-
-  /**
-   * An array of strings passed to this.get to lookup model id values for the <a href="#property_route">
-   *
-   * @property routeIdPaths
-   * @type {Array}
-   */
-
-  /**
-   * The related object.
-   *
-   * @property related
-   * @type {Object}
-   * @routeIdPathscategory computed
-   * @requires path,parent
-   */
   related: computed(
     'path',
     'parent',
@@ -132,35 +61,24 @@ export default Indicator.extend({
     }
   ),
 
-  /**
-   * The index of the related object.
-   *
-   * @property relatedIndex
-   * @type {Number}
-   * @category computed
-   * @requires related
-   */
   relatedIndex: computed(
     'related',
     'parent',
     'path',
-    'model',
-    'relatedId',
-    'relatedIdLocal',
     function () {
       return get(this.parent, this.path).indexOf(this.related);
     }
   ),
 
-  /**
-   * An array of property names that correspond to model.ids for the link-to.
-   *
-   * @property models
-   * @type {Array}
-   * @category computed
-   * @requires routeIdPaths
-   */
-  models: map('routeIdPaths', 'model', function (p) {
-    return this.get(p);
+  models: computed('routeIdPaths.[]', 'relatedIndex', 'model', function () {
+    let paths = this.routeIdPaths;
+
+    if (!paths) {
+      return [];
+    }
+
+    return paths.map((p) => this.get(p));
   }),
 });
+
+export default MdIndicatorRelatedComponent;

--- a/app/pods/components/control/md-indicator/related/component.js
+++ b/app/pods/components/control/md-indicator/related/component.js
@@ -36,15 +36,12 @@ export default Indicator.extend({
    */
 
   init() {
-    this.type = this.type || 'info';
-
     this._super(...arguments);
-
+    this.type = this.type || 'info';
     this.linkText = this.linkText || 'Open Related';
-
     this.classNames = ['md-indicator-related', `md-${this.type}`].concat(
-      this
-      .classNames);
+      this.classNames
+    );
   },
 
   isVisible: bool('related'),
@@ -121,10 +118,19 @@ export default Indicator.extend({
    * @routeIdPathscategory computed
    * @requires path,parent
    */
-  related: computed('path', 'parent', function () {
-    return get(this.parent, this.path).findBy(this.relatedId, get(this
-      .model, this.relatedIdLocal || this.relatedId));
-  }),
+  related: computed(
+    'path',
+    'parent',
+    'model',
+    'relatedId',
+    'relatedIdLocal',
+    function () {
+      return get(this.parent, this.path).findBy(
+        this.relatedId,
+        get(this.model, this.relatedIdLocal || this.relatedId)
+      );
+    }
+  ),
 
   /**
    * The index of the related object.
@@ -134,9 +140,17 @@ export default Indicator.extend({
    * @category computed
    * @requires related
    */
-  relatedIndex: computed('related', function () {
-    return get(this.parent, this.path).indexOf(this.related);
-  }),
+  relatedIndex: computed(
+    'related',
+    'parent',
+    'path',
+    'model',
+    'relatedId',
+    'relatedIdLocal',
+    function () {
+      return get(this.parent, this.path).indexOf(this.related);
+    }
+  ),
 
   /**
    * An array of property names that correspond to model.ids for the link-to.
@@ -146,7 +160,7 @@ export default Indicator.extend({
    * @category computed
    * @requires routeIdPaths
    */
-  models: map('routeIdPaths', function (p) {
+  models: map('routeIdPaths', 'model', function (p) {
     return this.get(p);
-  })
+  }),
 });

--- a/app/pods/components/control/md-record-table/component.js
+++ b/app/pods/components/control/md-record-table/component.js
@@ -1,30 +1,37 @@
 import { computed, get, defineProperty, observer } from '@ember/object';
-import { run } from '@ember/runloop';
+import { next } from '@ember/runloop';
+import { A } from '@ember/array';
+import classic from 'ember-classic-decorator';
 import Table from 'mdeditor/pods/components/md-models-table/component';
-import { warn } from '@ember/debug';
-import { isArray, A } from '@ember/array';
 
-export default Table.extend({
-  /**
-   * @module mdeditor
-   * @submodule components-control
-   */
+/**
+ * @module mdeditor
+ * @submodule components-control
+ */
 
-  /**
-   * Table used to display objects. Includes column to toggle selection for all
-   * rows.
-   *
-   *```handlebars
-   * \{{control/md-record-table
-   *   data=model.data
-   *   columns=model.columns
-   *   select=callback
-   * }}
-   * ```
-   *
-   * @class md-select-table
-   * @extends models-table
-   */
+/**
+ * Table used to display objects. Includes column to toggle selection for all
+ * rows.
+ *
+ * ```handlebars
+ * {{control/md-record-table
+ *   data=model.data
+ *   columns=model.columns
+ *   select=callback
+ * }}
+ * ```
+ *
+ * @class md-record-table
+ * @extends models-table
+ */
+@classic
+class MdRecordTableComponent extends Table {
+  classNames = ['md-record-table'];
+
+  selectProperty = '_selected';
+
+  hideActionsColumn = false;
+
   init() {
     this.dataColumns = this.dataColumns || [];
     this.filteringIgnoreCase = this.filteringIgnoreCase || true;
@@ -33,7 +40,7 @@ export default Table.extend({
     defineProperty(
       this,
       'columns',
-      computed('dataColumns', 'checkColumn', function () {
+      computed('dataColumns', 'checkColumn', 'actionsColumn', function () {
         let chk = this.checkColumn;
         let action = this.actionsColumn;
         let cols = A().concat(this.dataColumns);
@@ -50,10 +57,10 @@ export default Table.extend({
       })
     );
 
-    // Populate selectedItems from pre-existing selectProperty values so
-    // checkboxes display the correct initial checked state.
+    super.init(...arguments);
+
     this.initFromSelectProperty();
-  },
+  }
 
   /**
    * Seed selectedItems from the selectProperty flag on each data item.
@@ -69,34 +76,37 @@ export default Table.extend({
 
     let selected = A(data.filter((item) => get(item, prop)));
     this.set('selectedItems', selected);
-  },
+  }
 
   /**
-   * Re-initialize selectedItems when the data array itself is replaced
-   * (e.g. a new import is loaded into the same component instance).
+   * Callback on row selection.
+   *
+   * @method select
+   * @param {Object} rec Selected record.
+   * @param {Number} index Selected row index.
+   * @param {Array} selected Selected records.
+   * @return {Array} Selected records.
    */
+  select(rec, index, selected) {
+    return selected;
+  }
+}
+
+MdRecordTableComponent.reopen({
   dataObserver: observer('data', function () {
     this.initFromSelectProperty();
   }),
-  classNames: ['md-record-table'],
 
-  /**
-   * Observer to sync parent's selectedItems array with our selectProperty
-   */
   syncSelectedItemsObserver: observer('selectedItems.[]', function () {
-    // Whenever selectedItems changes, sync the selectProperty on all records
-    run.next(() => {
+    next(() => {
       let prop = this.selectProperty;
       let data = this.data;
-
-      // Get parent's actual selectedItems (not our override)
       let parentSelectedItems = this.get('selectedItems');
 
       if (!prop || !data) {
         return;
       }
 
-      // Sync all records so their selectProperty matches being in parent's selectedItems
       data.forEach((item) => {
         const isSelected =
           parentSelectedItems && parentSelectedItems.includes(item);
@@ -108,57 +118,6 @@ export default Table.extend({
     });
   }),
 
-  /**
-   * Property name used to identify selected records. Should begin with underscore.
-   *
-   * @property selectProperty
-   * @type {String}
-   * @default "_selected"
-   * @static
-   * @readOnly
-   * @required
-   */
-  selectProperty: '_selected',
-
-  /**
-   * Array of table records
-   *
-   * @property data
-   * @type {Array}
-   * @default []
-   * @required
-   */
-
-  /**
-   * Array of column configs for the table.
-   * See http://onechiporenko.github.io/ember-models-table
-   *
-   * ```javascript
-   * [{
-   *  propertyName: 'id',
-   *  title: 'ID'
-   * }, {
-   *  title: '',
-   *  template: 'components/leaflet-table/actions',
-   *  className: 'text-center text-nowrap'
-   * }]
-   * ```
-   *
-   * @property dataColumns
-   * @type {Array}
-   * @required
-   * @default []
-   */
-
-  /**
-   * Column configs for the checkbox column.
-   * See http://onechiporenko.github.io/ember-models-table
-   *
-   *
-   * @property checkColumns
-   * @type {Object}
-   * @required
-   */
   checkColumn: computed(function () {
     return {
       component: 'components/md-models-table/components/check',
@@ -168,24 +127,6 @@ export default Table.extend({
       className: 'text-center',
     };
   }),
-
-  /**
-   * Column configs for the action column.
-   * See http://onechiporenko.github.io/ember-models-table
-   *
-   *
-   * @property actionsColumn
-   * @type {Object}
-   * @required
-   */
-  /**
-   * Flag to hide the actions column
-   *
-   * @property hideActionsColumn
-   * @type {Boolean}
-   * @default false
-   */
-  hideActionsColumn: false,
 
   actionsColumn: computed('allActions', 'hideActionsColumn', function () {
     if (this.hideActionsColumn) {
@@ -207,20 +148,6 @@ export default Table.extend({
       showSlider: this.showSlider,
     };
   }),
-
-  // Remove our custom selectedItems - let parent handle it
-  // selectedItems is managed by the parent ember-models-table component
-
-  /**
-   * Callback on row selection.
-   *
-   * @method select
-   * @param {Object} rec Selected record.
-   * @param {Number} index Selected row index.
-   * @param {Array} selected Selected records.
-   * @return {Array} Selected records.
-   */
-  select(rec, index, selected) {
-    return selected;
-  },
 });
+
+export default MdRecordTableComponent;

--- a/app/pods/components/control/md-record-table/component.js
+++ b/app/pods/components/control/md-record-table/component.js
@@ -50,8 +50,6 @@ export default Table.extend({
       })
     );
 
-    this._super(...arguments);
-
     // Populate selectedItems from pre-existing selectProperty values so
     // checkboxes display the correct initial checked state.
     this.initFromSelectProperty();

--- a/app/pods/components/control/md-select-table/component.js
+++ b/app/pods/components/control/md-select-table/component.js
@@ -67,13 +67,13 @@ export default Table.extend({
     return selected;
   },
 
-  _onSelectedItemsChanged: observer('selectedItems.[]', function() {
+  _onSelectedItemsChanged: observer('selectedItems.[]', function () {
     this.select(this.selectedItems);
   }),
 
   actions: {
     clickOnRow() {
       this._super(...arguments);
-    }
-  }
+    },
+  },
 });

--- a/app/pods/components/control/md-select-table/component.js
+++ b/app/pods/components/control/md-select-table/component.js
@@ -1,60 +1,31 @@
 import { observer } from '@ember/object';
+import classic from 'ember-classic-decorator';
 import Table from 'mdeditor/pods/components/md-models-table/component';
 
-export default Table.extend({
-  /**
-   * @module mdeditor
-   * @submodule components-control
-   */
+/**
+ * @module mdeditor
+ * @submodule components-control
+ */
 
-  /**
-   * Table with action on row click. Used to select objects(records).
-   *
-   *```handlebars
-   * \{{control/md-select-table
-   *   data=model.data
-   *   columns=model.columns
-   *   select=callback
-   * }}
-   * ```
-   *
-   * @class md-select-table
-   * @extends models-table
-   */
+/**
+ * Table with action on row click. Used to select objects (records).
+ *
+ * ```handlebars
+ * {{control/md-select-table
+ *   data=model.data
+ *   columns=model.columns
+ *   select=callback
+ * }}
+ * ```
+ *
+ * @class md-select-table
+ * @extends models-table
+ */
+@classic
+class MdSelectTableComponent extends Table {
+  classNames = ['md-select-table'];
 
-  classNames: ['md-select-table'],
-
-  /**
-   * Array of table records
-   *
-   * @property data
-   * @type {Array}
-   * @default []
-   * @required
-   */
-
-  /**
-   * Array of column configs for the table.
-   * See http://onechiporenko.github.io/ember-models-table
-   *
-   * ```javascript
-   * [{
-   *  propertyName: 'id',
-   *  title: 'ID'
-   * }, {
-   *  title: '',
-   *  template: 'components/leaflet-table/actions',
-   *  className: 'text-center text-nowrap'
-   * }]
-   * ```
-   *
-   * @property columns
-   * @type {Array}
-   * @required
-   * @default []
-   */
-
-  filteringIgnoreCase: true,
+  filteringIgnoreCase = true;
 
   /**
    * Callback on row selection.
@@ -65,8 +36,10 @@ export default Table.extend({
    */
   select(selected) {
     return selected;
-  },
+  }
+}
 
+MdSelectTableComponent.reopen({
   _onSelectedItemsChanged: observer('selectedItems.[]', function () {
     this.select(this.selectedItems);
   }),
@@ -77,3 +50,5 @@ export default Table.extend({
     },
   },
 });
+
+export default MdSelectTableComponent;

--- a/app/pods/components/input/md-codelist-multi/component.js
+++ b/app/pods/components/input/md-codelist-multi/component.js
@@ -4,95 +4,76 @@
  */
 
 import { isArray, A } from '@ember/array';
-
 import { computed, set } from '@ember/object';
+import classic from 'ember-classic-decorator';
 import MdCodelist from '../md-codelist/component';
 
-export default MdCodelist.extend({
-  classNames: ['md-codelist-multi'],
+/**
+ * Specialized select list control for displaying and selecting options in
+ * mdCodes codelists. Extends md-codelist. Allows selection of multiple
+ * options.
+ *
+ * ```handlebars
+ * {{input/md-codelist-multi
+ *   value=array
+ *   create=true
+ *   tooltip=true
+ *   icon=false
+ *   mdCodeName="codeName"
+ *   closeOnSelect=false
+ *   placeholder="Select or enter one or more"
+ * }}
+ * ```
+ *
+ * @class md-codelist-multi
+ * @extends md-codelist
+ */
+@classic
+class MdCodelistMultiComponent extends MdCodelist {
+  init() {
+    super.init(...arguments);
+
+    this.setValue = this.setValue.bind(this);
+
+    if (!(this.model && this.path)) {
+      set(this, 'localValue', this.value || []);
+    }
+  }
+
+  setValue(selected) {
+    let sel;
+
+    if (this.create && !isArray(selected)) {
+      sel = this.selectedItem.compact();
+      sel.pushObject(selected);
+    } else {
+      sel = selected;
+    }
+
+    let nextValue = (sel || []).mapBy('codeId');
+
+    if (this.model && this.path) {
+      set(this, 'value', nextValue);
+    } else {
+      set(this, 'localValue', nextValue);
+    }
+
+    this.change();
+  }
+}
+
+MdCodelistMultiComponent.reopen({
   localValue: null,
-  /**
-   * Specialized select list control for displaying and selecting options in
-   * mdCodes codelists. Extends md-codelist. Allows selection of multiple
-   * options.
-   *
-   * ```handlebars
-   * \{{input/md-codelist-multi
-   *   value=array
-   *   create=true
-   *   tooltip=true
-   *   icon=false
-   *   mdCodeName="codeName"
-   *   closeOnSelect=false
-   *   placeholder="Select or enter one or more"
-   * }}
-   * ```
-   *
-   * @class md-codelist-multi
-   * @constructor
-   * @extends md-codelist
-   */
-
-  /**
-   * Initial value, returned value.
-   * Accepts an Array of strings.
-   *
-   * Example: `["foo","bar"]`
-   *
-   * @property value
-   * @type Array
-   * @return Array
-   * @required
-   */
-
-  /**
-   * The multiple property for power-select-with-create
-   *
-   * @property multiple
-   * @private
-   * @type Boolean
-   * @default true
-   */
   multiple: true,
+  closeOnSelect: false,
+  placeholder: 'Select one or more options',
 
-  /**
-   * The component to render
-   *
-   * @property theComponent
-   * @type Ember.computed
-   * @return String
-   */
   theComponent: computed('create', function () {
     return this.create
       ? 'power-select-multiple-with-create'
       : 'power-select-multiple';
   }),
 
-  /**
-   * Whether to close the selection list after a selection has been made.
-   *
-   * @property closeOnSelect
-   * @type Boolean
-   * @default false
-   */
-  closeOnSelect: false,
-
-  /**
-   * The string to display when no option is selected.
-   *
-   * @property placeholder
-   * @type String
-   * @default 'Select one or more options'
-   */
-  placeholder: 'Select one or more options',
-
-  /**
-   * The currently selected item in the codelist
-   *
-   * @property selectedItem
-   * @type Ember.computed
-   * @return PromiseObject
-   */
   effectiveValue: computed('value', 'localValue', 'model', 'path', function () {
     return this.model && this.path ? this.value : this.localValue;
   }),
@@ -106,17 +87,10 @@ export default MdCodelist.extend({
         return value.includes(item['codeId']);
       });
     }
+
     return null;
   }),
 
-  /**
-   * If a value is provided by the user which is not in the codelist and 'create=true'
-   * the new value will be added into the codelist array
-   *
-   * @property codelist
-   * @type Ember.computed
-   * @return Array
-   */
   codelist: computed('effectiveValue', 'filterId', 'mapped', function () {
     let existing = this.mapped || A([]);
     let value = this.effectiveValue;
@@ -135,42 +109,11 @@ export default MdCodelist.extend({
 
     return A([...existing, ...extra]).rejectBy('codeId', filter);
   }),
-
-  /**
-   * Set the value on the select.
-   *
-   * @method setValue
-   * @param {Array|Object} selected The value to set. Generally, an array of
-   * selected objects, unless using the create option.
-   */
-  setValue(selected) {
-    let sel;
-
-    //power-select-with-create always sends a single object onCreate
-    //we need to add that object to the selectedItem array
-    if (this.create && !isArray(selected)) {
-      sel = this.selectedItem.compact();
-      sel.pushObject(selected);
-    } else {
-      sel = selected;
-    }
-
-    let nextValue = (sel || []).mapBy('codeId');
-
-    if (this.model && this.path) {
-      set(this, 'value', nextValue);
-    } else {
-      set(this, 'localValue', nextValue);
-    }
-
-    this.change();
-  },
-
-  init() {
-    this._super(...arguments);
-    this.setValue = this.setValue.bind(this);
-    if (!(this.model && this.path)) {
-      set(this, 'localValue', this.value || []);
-    }
-  },
 });
+
+MdCodelistMultiComponent.prototype.classNames = [
+  ...MdCodelist.prototype.classNames,
+  'md-codelist-multi',
+];
+
+export default MdCodelistMultiComponent;

--- a/app/pods/components/input/md-input/component.js
+++ b/app/pods/components/input/md-input/component.js
@@ -182,6 +182,8 @@ export default class MdInputComponent extends Component {
         //Ember.run.once(()=>model.set(valuePath, ""));
       }
 
+      const explicitRequired = this.required;
+
       if (this.type === 'number') {
         let attribute = `model.${valuePath}`;
 
@@ -220,15 +222,33 @@ export default class MdInputComponent extends Component {
         computed(
           'validation.options.presence{presence,disabled}',
           'disabled',
-          function () {
-            return (
-              !this.disabled &&
-              this.validation?.options?.presence?.presence &&
-              !this.validation?.options?.presence?.disabled
-            );
+          '_requiredOverride',
+          {
+            get() {
+              let fromValidation =
+                !this.disabled &&
+                this.validation?.options?.presence?.presence &&
+                !this.validation?.options?.presence?.disabled;
+
+              if (this._requiredOverride !== undefined) {
+                return Boolean(this._requiredOverride) || fromValidation;
+              }
+
+              return fromValidation;
+            },
+
+            set(key, value) {
+              set(this, '_requiredOverride', value);
+
+              return value;
+            },
           }
-        ).readOnly()
+        )
       );
+
+      if (explicitRequired) {
+        set(this, '_requiredOverride', explicitRequired);
+      }
 
       defineProperty(
         this,

--- a/app/pods/components/input/md-select-contact/component.js
+++ b/app/pods/components/input/md-select-contact/component.js
@@ -4,100 +4,44 @@
  */
 
 import { inject as service } from '@ember/service';
-
 import { computed } from '@ember/object';
-import Select from '../md-codelist/component';
+import classic from 'ember-classic-decorator';
+import MdCodelist from '../md-codelist/component';
 
-export default Select.extend({
-  /**
-   * Specialized select list control for displaying and selecting
-   * contacts.
-   *
-   * @class md-select-contacts
-   * @constructor
-   * @extends md-select
-   */
+/**
+ * Specialized select list control for displaying and selecting a contact.
+ *
+ * @class md-select-contact
+ * @extends md-codelist
+ */
+@classic
+class MdSelectContactComponent extends MdCodelist {
+  mdCodeName = 'contacts';
 
-  /**
-   * The contacts service
-   *
-   * @property contacts
-   * @type {Ember.Service}
-   * @readOnly
-   */
+  valuePath = 'contactId';
+
+  namePath = 'title';
+
+  contactType = 'contacts';
+}
+
+MdSelectContactComponent.reopen({
   contacts: service(),
 
-  /**
-   * The default CSS classnames
-   *
-   * @property classNames
-   * @type {Array}
-   * @default ['md-select-contact']
-   * @readOnly
-   */
-  classNames: ['md-select-contact'],
-
-  /**
-   * The default codelist name. Should not be overridden.
-   *
-   * @property classNames
-   * @protected
-   * @type {String}
-   * @default 'contacts'
-   * @readOnly
-   */
-  mdCodeName: 'contacts',
-
-  /**
-   * The property that holds the select item value. Should not be overridden.
-   *
-   * @property valuePath
-   * @protected
-   * @type {String}
-   * @default 'valuePath'
-   * @readOnly
-   */
-  valuePath: 'contactId',
-
-  /**
-   * The property that holds the select item text. Should not be overridden.
-   *
-   * @property namePath
-   * @protected
-   * @type {String}
-   * @default 'namePath'
-   * @readOnly
-   */
-  namePath: 'title',
-
-  /**
-   * The contact type to display in the list. Choices are `organizations` or
-   * `individuals` or 'contacts'. Passing any other value will default to
-   * 'contacts'.
-   *
-   * @property contactType
-   * @protected
-   * @type {String}
-   * @default 'contacts'
-   */
-  contactType: 'contacts',
-
-  /**
-   * The contact list mapped from the store to a codelist.
-   *
-   * @property mapped
-   * @type {Array}
-   * @category computed
-   * @requires contacts.[]
-   */
-  mapped: computed('contacts.mapped.[]','contactType', function () {
+  mapped: computed('contacts.mapped.[]', 'contactType', function () {
     let type = this.contactType;
 
-    if(!['individuals','organizations'].includes(type)){
+    if (!['individuals', 'organizations'].includes(type)) {
       return this.contacts.get('contactsCodes');
     }
 
-    return this.contacts
-      .get(type + 'Codes');
-  })
+    return this.contacts.get(type + 'Codes');
+  }),
 });
+
+MdSelectContactComponent.prototype.classNames = [
+  ...MdCodelist.prototype.classNames,
+  'md-select-contact',
+];
+
+export default MdSelectContactComponent;

--- a/app/pods/components/input/md-select-contacts/component.js
+++ b/app/pods/components/input/md-select-contacts/component.js
@@ -4,100 +4,45 @@
  */
 
 import { inject as service } from '@ember/service';
-
 import { computed } from '@ember/object';
-import Select from '../md-codelist-multi/component';
+import classic from 'ember-classic-decorator';
+import MdCodelistMulti from '../md-codelist-multi/component';
 
-export default Select.extend({
-  /**
-   * Specialized select list control for displaying and selecting
-   * contacts.
-   *
-   * @class md-select-contacts
-   * @constructor
-   * @extends md-select
-   */
+/**
+ * Specialized select list control for displaying and selecting multiple
+ * contacts.
+ *
+ * @class md-select-contacts
+ * @extends md-codelist-multi
+ */
+@classic
+class MdSelectContactsComponent extends MdCodelistMulti {
+  mdCodeName = 'contacts';
 
-  /**
-   * The contacts service
-   *
-   * @property contacts
-   * @type {Ember.Service}
-   * @readOnly
-   */
+  valuePath = 'contactId';
+
+  namePath = 'title';
+
+  contactType = 'contacts';
+}
+
+MdSelectContactsComponent.reopen({
   contacts: service(),
 
-  /**
-   * The default CSS classnames
-   *
-   * @property classNames
-   * @type {Array}
-   * @default ['md-select-organization']
-   * @readOnly
-   */
-  classNames: ['md-select-contact'],
-
-  /**
-   * The default codelist name. Should not be overridden.
-   *
-   * @property classNames
-   * @protected
-   * @type {String}
-   * @default 'contacts'
-   * @readOnly
-   */
-  mdCodeName: 'contacts',
-
-  /**
-   * The property that holds the select item value. Should not be overridden.
-   *
-   * @property valuePath
-   * @protected
-   * @type {String}
-   * @default 'valuePath'
-   * @readOnly
-   */
-  valuePath: 'contactId',
-
-  /**
-   * The property that holds the select item text. Should not be overridden.
-   *
-   * @property namePath
-   * @protected
-   * @type {String}
-   * @default 'namePath'
-   * @readOnly
-   */
-  namePath: 'title',
-
-  /**
-   * The contact type to display in the list. Choices are `organizations` or
-   * `individuals` or 'contacts'. Passing any other value will default to
-   * 'contacts'.
-   *
-   * @property contactType
-   * @protected
-   * @type {String}
-   * @default 'contacts'
-   */
-  contactType: 'contacts',
-
-  /**
-   * The contact list mapped from the store to a codelist.
-   *
-   * @property mapped
-   * @type {Array}
-   * @category computed
-   * @requires contacts.[]
-   */
-  mapped: computed('contacts.mapped.[]','contactType', function () {
+  mapped: computed('contacts.mapped.[]', 'contactType', function () {
     let type = this.contactType;
 
-    if(!['individuals','organizations'].includes(type)){
+    if (!['individuals', 'organizations'].includes(type)) {
       return this.contacts.get('contactsCodes');
     }
 
-    return this.contacts
-      .get(type + 'Codes');
-  })
+    return this.contacts.get(type + 'Codes');
+  }),
 });
+
+MdSelectContactsComponent.prototype.classNames = [
+  ...MdCodelistMulti.prototype.classNames,
+  'md-select-contact',
+];
+
+export default MdSelectContactsComponent;

--- a/app/pods/components/input/md-select/component.js
+++ b/app/pods/components/input/md-select/component.js
@@ -389,6 +389,8 @@ export default class MdSelectComponent extends Component {
         //Ember.run.once(()=>model.set(path, ""));
       }
 
+      const explicitRequired = this.required;
+
       defineProperty(this, 'value', alias(`model.${path}`));
 
       defineProperty(
@@ -403,15 +405,33 @@ export default class MdSelectComponent extends Component {
         computed(
           'validation.options.presence.{presence,disabled}',
           'disabled',
-          function () {
-            return (
-              !this.disabled &&
-              this.validation?.options?.presence?.presence &&
-              !this.validation?.options?.presence?.disabled
-            );
+          '_requiredOverride',
+          {
+            get() {
+              let fromValidation =
+                !this.disabled &&
+                this.validation?.options?.presence?.presence &&
+                !this.validation?.options?.presence?.disabled;
+
+              if (this._requiredOverride !== undefined) {
+                return Boolean(this._requiredOverride) || fromValidation;
+              }
+
+              return fromValidation;
+            },
+
+            set(key, value) {
+              set(this, '_requiredOverride', value);
+
+              return value;
+            },
           }
-        ).readOnly()
+        )
       );
+
+      if (explicitRequired) {
+        set(this, '_requiredOverride', explicitRequired);
+      }
 
       defineProperty(
         this,

--- a/app/pods/components/input/md-textarea/component.js
+++ b/app/pods/components/input/md-textarea/component.js
@@ -5,7 +5,7 @@
 
 import Component from '@ember/component';
 import classic from 'ember-classic-decorator';
-import { action, computed, defineProperty } from '@ember/object';
+import { action, computed, defineProperty, set } from '@ember/object';
 import { alias, not, notEmpty, and, or } from '@ember/object/computed';
 import { isBlank } from '@ember/utils';
 import { assert, debug } from '@ember/debug';
@@ -195,6 +195,8 @@ export default class MdTextareaComponent extends Component {
         //Ember.run.once(()=>model.set(valuePath, ""));
       }
 
+      const explicitRequired = this.required;
+
       defineProperty(this, 'value', alias(`model.${valuePath}`));
 
       defineProperty(
@@ -209,15 +211,33 @@ export default class MdTextareaComponent extends Component {
         computed(
           'validation.options.presence{presence,disabled}',
           'disabled',
-          function () {
-            return (
-              !this.disabled &&
-              this.validation?.options?.presence?.presence &&
-              !this.validation?.options?.presence?.disabled
-            );
+          '_requiredOverride',
+          {
+            get() {
+              let fromValidation =
+                !this.disabled &&
+                this.validation?.options?.presence?.presence &&
+                !this.validation?.options?.presence?.disabled;
+
+              if (this._requiredOverride !== undefined) {
+                return Boolean(this._requiredOverride) || fromValidation;
+              }
+
+              return fromValidation;
+            },
+
+            set(key, value) {
+              set(this, '_requiredOverride', value);
+
+              return value;
+            },
           }
-        ).readOnly()
+        )
       );
+
+      if (explicitRequired) {
+        set(this, '_requiredOverride', explicitRequired);
+      }
 
       defineProperty(
         this,

--- a/app/pods/components/object/md-attribute/component.js
+++ b/app/pods/components/object/md-attribute/component.js
@@ -1,4 +1,5 @@
 import Component from '@ember/component';
+import classic from 'ember-classic-decorator';
 import EmberObject, { set, get, computed } from '@ember/object';
 import { alias } from '@ember/object/computed';
 import { once } from '@ember/runloop';
@@ -44,60 +45,17 @@ const TemplateClass = EmberObject.extend(Validations, {
   },
 });
 
-const theComp = Component.extend(Validations, {
-  didReceiveAttrs() {
-    this._super(...arguments);
+@classic
+export default class MdAttributeComponent extends Component.extend(Validations) {
+  tagName = 'form';
 
-    let model = this.model;
+  codeName = alias('model.codeName');
+  dataType = alias('model.dataType');
+  definition = alias('model.definition');
+  allowNull = alias('model.allowNull');
+  domains = alias('dictionary.domain');
 
-    once(this, function () {
-      set(model, 'allowNull', get(model, 'allowNull') ?? false);
-      set(model, 'reference', get(model, 'reference') ?? {});
-      set(model, 'alias', get(model, 'alias') ?? []);
-      set(model, 'valueRange', get(model, 'valueRange') ?? []);
-      set(model, 'timePeriod', get(model, 'timePeriod') ?? []);
-    });
-  },
-
-  /**
-   * The string representing the path in the profile object for the domain.
-   *
-   * @property profilePath
-   * @type {String}
-   * @default 'false'
-   * @required
-   */
-
-  /**
-   * The object to use as the data model for the domain.
-   *
-   * @property model
-   * @type {Object}
-   * @required
-   */
-
-  tagName: 'form',
-  codeName: alias('model.codeName'),
-  dataType: alias('model.dataType'),
-  definition: alias('model.definition'),
-  allowNull: alias('model.allowNull'),
-  domains: alias('dictionary.domain'),
-
-  domainList: computed('domains.{@each.domainId,@each.codeName}', function () {
-    let domains = this.domains || [];
-
-    return domains.map((domain) => {
-      if (get(domain, 'domainId')) {
-        return {
-          codeId: get(domain, 'domainId'),
-          codeName: get(domain, 'codeName'),
-          tooltip: get(domain, 'description'),
-        };
-      }
-    });
-  }),
-
-  rangeTemplate: EmberObject.extend(
+  rangeTemplate = EmberObject.extend(
     buildValidations({
       minRangeValue: [
         validator('presence', {
@@ -117,7 +75,36 @@ const theComp = Component.extend(Validations, {
         this._super(...arguments);
       },
     }
-  ),
-});
+  );
 
-export { Validations, TemplateClass as Template, theComp as default };
+  didReceiveAttrs() {
+    super.didReceiveAttrs(...arguments);
+
+    let model = this.model;
+
+    once(this, function () {
+      set(model, 'allowNull', get(model, 'allowNull') ?? false);
+      set(model, 'reference', get(model, 'reference') ?? {});
+      set(model, 'alias', get(model, 'alias') ?? []);
+      set(model, 'valueRange', get(model, 'valueRange') ?? []);
+      set(model, 'timePeriod', get(model, 'timePeriod') ?? []);
+    });
+  }
+
+  @computed('domains.{@each.domainId,@each.codeName}')
+  get domainList() {
+    let domains = this.domains || [];
+
+    return domains.map((domain) => {
+      if (get(domain, 'domainId')) {
+        return {
+          codeId: get(domain, 'domainId'),
+          codeName: get(domain, 'codeName'),
+          tooltip: get(domain, 'description'),
+        };
+      }
+    });
+  }
+}
+
+export { Validations, TemplateClass as Template };

--- a/app/pods/components/object/md-contact-identifier-array/component.js
+++ b/app/pods/components/object/md-contact-identifier-array/component.js
@@ -2,23 +2,20 @@ import Component from '@ember/component';
 import classic from 'ember-classic-decorator';
 import EmObject from '@ember/object';
 import { A } from '@ember/array';
-import {
-  validator,
-  buildValidations
-} from 'ember-cp-validations';
+import { validator, buildValidations } from 'ember-cp-validations';
 
 const Validations = buildValidations({
-  'identifier': [
+  identifier: [
     validator('presence', {
       presence: true,
-      ignoreBlank: true
-    })
+      ignoreBlank: true,
+    }),
   ],
-  'namespace': [
+  namespace: [
     validator('presence', {
-      presence: true
-    })
-  ]
+      presence: true,
+    }),
+  ],
 });
 
 /**
@@ -50,8 +47,8 @@ export default class MdContactIdentifierArrayComponent extends Component {
    */
   templateClass = EmObject.extend(Validations, {
     init() {
-      this._super(...arguments);
+      super.init(...arguments);
       this.set('service', A());
-    }
+    },
   });
 }

--- a/app/pods/components/object/md-contact-identifier-array/component.js
+++ b/app/pods/components/object/md-contact-identifier-array/component.js
@@ -47,7 +47,7 @@ export default class MdContactIdentifierArrayComponent extends Component {
    */
   templateClass = EmObject.extend(Validations, {
     init() {
-      super.init(...arguments);
+      this._super(...arguments);
       this.set('service', A());
     },
   });

--- a/app/pods/components/object/md-domainitem/component.js
+++ b/app/pods/components/object/md-domainitem/component.js
@@ -28,7 +28,7 @@ const Validations = buildValidations({
 
 const TemplateClass = EmberObject.extend(Validations, {
   init() {
-    this._super(...arguments);
+    super.init(...arguments);
 
     set(this, 'reference', {});
   },

--- a/app/pods/components/object/md-domainitem/component.js
+++ b/app/pods/components/object/md-domainitem/component.js
@@ -1,4 +1,5 @@
 import Component from '@ember/component';
+import classic from 'ember-classic-decorator';
 import EmberObject, { set, get } from '@ember/object';
 import { alias } from '@ember/object/computed';
 import { once } from '@ember/runloop';
@@ -28,44 +29,29 @@ const Validations = buildValidations({
 
 const TemplateClass = EmberObject.extend(Validations, {
   init() {
-    super.init(...arguments);
+    this._super(...arguments);
 
     set(this, 'reference', {});
   },
 });
 
-const theComp = Component.extend(Validations, {
+@classic
+export default class MdDomainitemComponent extends Component.extend(Validations) {
+  tagName = 'form';
+
+  name = alias('model.name');
+  value = alias('model.value');
+  definition = alias('model.definition');
+
   didReceiveAttrs() {
-    this._super(...arguments);
+    super.didReceiveAttrs(...arguments);
 
     let model = this.model;
 
     once(this, function () {
       set(model, 'reference', get(model, 'reference') ?? {});
     });
-  },
+  }
+}
 
-  /**
-   * The string representing the path in the profile object for the domain.
-   *
-   * @property profilePath
-   * @type {String}
-   * @default 'false'
-   * @required
-   */
-
-  /**
-   * The object to use as the data model for the domain.
-   *
-   * @property model
-   * @type {Object}
-   * @required
-   */
-
-  tagName: 'form',
-  name: alias('model.name'),
-  value: alias('model.value'),
-  definition: alias('model.definition'),
-});
-
-export { Validations, TemplateClass as Template, theComp as default };
+export { Validations, TemplateClass as Template };

--- a/app/pods/components/object/md-identifier-object-table/component.js
+++ b/app/pods/components/object/md-identifier-object-table/component.js
@@ -1,52 +1,24 @@
+import classic from 'ember-classic-decorator';
 import Identifier from '../md-identifier-array/component';
 
-export default Identifier.extend({
+/**
+ * mdEditor class for input and edit of mdJSON 'identifier' object arrays.
+ * The class manages the maintenance of an array of identifier objects
+ * using the md-object-table class.
+ *
+ * @module mdeditor
+ * @submodule components-object
+ * @class md-identifier-object-table
+ * @extends md-identifier-array
+ */
+@classic
+export default class MdIdentifierObjectTableComponent extends Identifier {
   /**
-   * mdEditor class for input and edit of mdJSON 'identifier' object
-   * arrays.
-   * The class manages the maintenance of an array of identifier
-   * objects using the md-object-table class.
-   *
-   * @module mdeditor
-   * @submodule components-object
-   * @class md-identifier-object-table
-   * @uses md-object-table
-   * @constructor
+   * Preview columns: inherits md-identifier-array default
+   * (`identifier,namespace,description`). A classic `.extend()` override of
+   * `identifier,namespace` did not replace the parent class field.
    */
+  ellipsis = true;
 
-  /**
-   * Label for the panel
-   *
-   * @property label
-   * @type {String}
-   * @default undefined
-   */
-
-  /**
-   * Array of identifiers
-   *
-   * @property model
-   * @type {Array}
-   * @default undefined
-   */
-
-  /**
-   * Attributes displayed in the preview table.
-   *
-   * @property attributes
-   * @type {String}
-   * @default 'identifier,namespace'
-   */
-  attributes: 'identifier,namespace',
-
-  ellipsis: true,
-
-  /**
-   * Default profile visibility
-   *
-   * @property visibility
-   * @type {Boolean}
-   * @default false
-   */
-  visibility: false
-});
+  visibility = false;
+}

--- a/app/pods/components/object/md-identifier/component.js
+++ b/app/pods/components/object/md-identifier/component.js
@@ -1,5 +1,6 @@
 import { and } from '@ember/object/computed';
 import Component from '@ember/component';
+import classic from 'ember-classic-decorator';
 import { action, computed, get, set } from '@ember/object';
 import { once } from '@ember/runloop';
 import { validator, buildValidations } from 'ember-cp-validations';
@@ -13,79 +14,58 @@ const Validations = buildValidations({
   ],
 });
 
-const theComp = Component.extend(Validations, {
+@classic
+export default class MdIdentifierComponent extends Component.extend(Validations) {
+  classNames = ['md-identifier'];
+  attributeBindings = ['data-spy'];
+
+  collapsible = false;
+  collapse = true;
+
+  isCollapsed = and('collapsible', 'collapse');
+
   init() {
-    this._super(...arguments);
+    super.init(...arguments);
     this._localModel = {};
-  },
+  }
 
   didReceiveAttrs() {
-    this._super(...arguments);
+    super.didReceiveAttrs(...arguments);
 
     let model = get(this, 'model') || this._localModel;
 
     once(this, function () {
       set(model, 'authority', get(model, 'authority') ?? {});
     });
-  },
+  }
 
-  classNames: ['md-identifier'],
-  attributeBindings: ['data-spy'],
-
-  /**
-   * The identifier object to render
-   *
-   * @property model
-   * @type {object}
-   * @required
-   */
-
-  /**
-   * Render short form of the identifier template, i.e. no authority
-   *
-   * @property short
-   * @type {Boolean}
-   */
-
-  /**
-   * Determines whether to render identifier field with confirmation button
-   *
-   * @property confirmIdentifier
-   * @type {Boolean}
-   */
-
-  effectiveModel: computed('model', '_localModel', function () {
+  @computed('model', '_localModel')
+  get effectiveModel() {
     return get(this, 'model') || this._localModel;
-  }),
+  }
 
-  identifier: computed('effectiveModel.identifier', {
-    get() {
-      return get(this, 'effectiveModel.identifier');
-    },
+  @computed('effectiveModel.identifier')
+  get identifier() {
+    return get(this, 'effectiveModel.identifier');
+  }
 
-    set(_key, value) {
-      set(this, 'effectiveModel.identifier', value);
-      return value;
-    },
-  }),
+  set identifier(value) {
+    set(this, 'effectiveModel.identifier', value);
+  }
 
-  namespace: computed('effectiveModel.namespace', {
-    get() {
-      return get(this, 'effectiveModel.namespace');
-    },
+  @computed('effectiveModel.namespace')
+  get namespace() {
+    return get(this, 'effectiveModel.namespace');
+  }
 
-    set(_key, value) {
-      set(this, 'effectiveModel.namespace', value);
-      return value;
-    },
-  }),
-  collapsible: false,
-  collapse: true,
-  isCollapsed: and('collapsible', 'collapse'),
+  set namespace(value) {
+    set(this, 'effectiveModel.namespace', value);
+  }
 
-  toggleCollapse: action(function () {
+  @action
+  toggleCollapse() {
     this.toggleProperty('collapse');
-  }),
-});
+  }
+}
 
-export { Validations, theComp as default };
+export { Validations };

--- a/app/pods/components/object/md-locale/component.js
+++ b/app/pods/components/object/md-locale/component.js
@@ -1,70 +1,50 @@
-import {
-  once
-} from '@ember/runloop';
-import {
-  validator,
-  buildValidations
-} from 'ember-cp-validations';
-import {
-  setProperties,
-  get
-} from '@ember/object';
-import {
-  copy
-} from 'ember-copy';
-import {
-  isNone
-} from '@ember/utils';
-import {
-  inject as service
-} from '@ember/service';
+import { once } from '@ember/runloop';
+import { validator, buildValidations } from 'ember-cp-validations';
+import { setProperties, get } from '@ember/object';
+import { copy } from 'ember-copy';
+import { isNone } from '@ember/utils';
+import { inject as service } from '@ember/service';
 import Component from '@ember/component';
-import {
-  assert
-} from '@ember/debug';
-import {
-  alias
-} from '@ember/object/computed';
+import classic from 'ember-classic-decorator';
+import { assert } from '@ember/debug';
+import { alias } from '@ember/object/computed';
 
 const Validations = buildValidations({
-  'language': validator('presence', {
+  language: validator('presence', {
     presence: true,
-    ignoreBlank: true
+    ignoreBlank: true,
   }),
-  'characterSet': validator('presence', {
+  characterSet: validator('presence', {
     presence: true,
-    ignoreBlank: true
-  })
+    ignoreBlank: true,
+  }),
 });
 
-const theComp = Component.extend(Validations, {
-  settings: service(),
+@classic
+export default class MdLocaleComponent extends Component.extend(Validations) {
+  @service settings;
+
+  language = alias('model.language');
+  characterSet = alias('model.characterSet');
 
   didReceiveAttrs() {
-    this._super(...arguments);
+    super.didReceiveAttrs(...arguments);
 
     let model = this.model || {};
     let settings = get(this, 'settings.data');
 
     assert('Model passed to md-locale must be an object', !isNone(model));
 
-    if(Object.keys(model).length === 0) {
+    if (Object.keys(model).length === 0) {
       once(() => {
         setProperties(model, {
           language: copy(settings.get('language')),
           characterSet: copy(settings.get('characterSet')),
-          country: copy(settings.get('country'))
+          country: copy(settings.get('country')),
         });
       });
     }
-  },
+  }
+}
 
-  language:alias('model.language'),
-  characterSet:alias('model.characterSet')
-});
-
-export {
-  Validations,
-  theComp as
-  default
-};
+export { Validations };

--- a/app/pods/components/object/md-maintenance/component.js
+++ b/app/pods/components/object/md-maintenance/component.js
@@ -4,8 +4,9 @@
  */
 
 import Component from '@ember/component';
-
-import { computed, setProperties, get, set } from '@ember/object';
+import classic from 'ember-classic-decorator';
+import { computed } from '@ember/object';
+import { setProperties, get, set } from '@ember/object';
 import { once } from '@ember/runloop';
 
 const formatMaint = function (model) {
@@ -19,63 +20,33 @@ const formatMaint = function (model) {
   return model;
 };
 
-const theComp = Component.extend({
-  /**
-   * mdEditor class for input and edit of mdJSON 'maintenance' objects.
-   *
-   * @class md-maintenance
-   * @constructor
-   *   myClass = new MyClass()
-   */
+@classic
+export default class MdMaintenanceComponent extends Component {
+  tagName = 'form';
 
-  tagName: 'form',
-
-  /**
-   * The string representing the path in the profile object.
-   *
-   * @property profilePath
-   * @type {String}
-   * @default "false"
-   * @required
-   */
-
-  /**
-   * The object to use as the data model.
-   *
-   * @property model
-   * @type {Object}
-   * @required
-   */
-
-  /**
-   * Setup default values for the model.
-   *
-   * @method didReceiveAttrs
-   */
   didReceiveAttrs() {
-    this._super(...arguments);
+    super.didReceiveAttrs(...arguments);
 
     once(this, function () {
       set(this, 'model', get(this, 'model') || {});
       formatMaint(this.model);
     });
-  },
+  }
 
-  scopes: computed('scope', {
-    get() {
-      let scope = get(this, 'model.scope');
-      return scope ? scope.mapBy('scopeCode') : [];
-    },
-    set(key, value) {
-      let map = value.map((itm) => {
-        return {
-          scopeCode: itm,
-        };
-      });
-      set(this, 'model.scope', map);
-      return value;
-    },
-  }),
-});
+  @computed('scope')
+  get scopes() {
+    let scope = get(this, 'model.scope');
+    return scope ? scope.mapBy('scopeCode') : [];
+  }
 
-export { formatMaint, theComp as default };
+  set scopes(value) {
+    let map = value.map((itm) => {
+      return {
+        scopeCode: itm,
+      };
+    });
+    set(this, 'model.scope', map);
+  }
+}
+
+export { formatMaint };

--- a/app/pods/components/object/md-object-table/component.js
+++ b/app/pods/components/object/md-object-table/component.js
@@ -130,7 +130,7 @@ export default class MdObjectTableComponent extends Component {
    *  ```javascript
    *  Ember.Object.extend({
    *    init() {
-   *      this._super(...arguments);
+   *      super.init(...arguments);
    *
    *      this.set('foo', A());
    *      this.set('bar', A());

--- a/app/pods/components/object/md-party/component.js
+++ b/app/pods/components/object/md-party/component.js
@@ -1,4 +1,5 @@
 import Component from '@ember/component';
+import classic from 'ember-classic-decorator';
 import EmberObject, { computed, get, set } from '@ember/object';
 import { A } from '@ember/array';
 import { once } from '@ember/runloop';
@@ -41,26 +42,16 @@ const Template = EmberObject.extend(Validations, {
   }),
 });
 
-const theComp = Component.extend(Validations, {
-  _contacts: computed('model', {
-    get() {
-      let party = get(this, 'model.party');
-      return party ? party.mapBy('contactId') : [];
-    },
-    set(key, value) {
-      let map = value.map((itm) => {
-        return {
-          contactId: itm,
-        };
-      });
-      set(this, 'model.party', map);
-      return value;
-    },
-  }),
+@classic
+export default class MdPartyComponent extends Component.extend(Validations) {
+  attributeBindings = ['data-spy'];
 
-  role: alias('model.role'),
+  templateClass = Template;
+
+  role = alias('model.role');
+
   didReceiveAttrs() {
-    this._super(...arguments);
+    super.didReceiveAttrs(...arguments);
 
     let model = this.model;
 
@@ -68,10 +59,22 @@ const theComp = Component.extend(Validations, {
       set(model, 'party', get(model, 'party') ?? []);
       set(model, 'role', get(model, 'role') ?? null);
     });
-  },
+  }
 
-  attributeBindings: ['data-spy'],
-  templateClass: Template,
-});
+  @computed('model')
+  get _contacts() {
+    let party = get(this, 'model.party');
+    return party ? party.mapBy('contactId') : [];
+  }
 
-export { Validations, Template, theComp as default };
+  set _contacts(value) {
+    let map = value.map((itm) => {
+      return {
+        contactId: itm,
+      };
+    });
+    set(this, 'model.party', map);
+  }
+}
+
+export { Validations, Template };

--- a/app/pods/components/object/md-raster/attrgroup/component.js
+++ b/app/pods/components/object/md-raster/attrgroup/component.js
@@ -38,7 +38,7 @@ export default Table.extend(Validations, {
   addAttrGroup: null,
 
   didReceiveAttrs() {
-    this._super(...arguments);
+    super.didReceiveAttrs(...arguments);
 
     let model = this.model;
 

--- a/app/pods/components/object/md-raster/attrgroup/component.js
+++ b/app/pods/components/object/md-raster/attrgroup/component.js
@@ -2,6 +2,7 @@ import Table from '../../md-array-table/component';
 import { once } from '@ember/runloop';
 import { alias } from '@ember/object/computed';
 import { get, set } from '@ember/object';
+import classic from 'ember-classic-decorator';
 import { validator, buildValidations } from 'ember-cp-validations';
 
 const Validations = buildValidations({
@@ -13,29 +14,33 @@ const Validations = buildValidations({
   ],
 });
 
-export default Table.extend(Validations, {
-  /**
-   * mdEditor class for input and edit of mdJSON 'coverageDescription.attributeGroup' object.
-   * The class manages the maintenance of an array of attributeGroup objects.
-   *
-   * ```handlebars
-   * \{{object/md-raster/attrgroup
-   *    model=model.attributeGroup
-   *    profilePath="path"
-   * }}
-   * ```
-   *
-   * @module mdeditor
-   * @submodule components-object-md-raster
-   * @constructor
-   * @class md-raster-attrgroup
-   * @uses md-array-table
-   */
+/**
+ * mdEditor class for input and edit of mdJSON 'coverageDescription.attributeGroup'
+ * object. The class manages the maintenance of an array of attributeGroup objects.
+ *
+ * ```handlebars
+ * {{object/md-raster/attrgroup
+ *   model=model.attributeGroup
+ *   profilePath="path"
+ * }}
+ * ```
+ *
+ * @module mdeditor
+ * @submodule components-object-md-raster
+ * @class md-raster-attrgroup
+ * @extends md-array-table
+ */
+@classic
+export default class MdRasterAttrgroupComponent extends Table.extend(Validations) {
+  editAttribute = null;
 
-  // Passed-in actions
-  editAttribute: null,
-  deleteAttrGroup: null,
-  addAttrGroup: null,
+  deleteAttrGroup = null;
+
+  addAttrGroup = null;
+
+  tagName = 'form';
+
+  attrCntType = alias('model.attributeContentType');
 
   didReceiveAttrs() {
     super.didReceiveAttrs(...arguments);
@@ -52,53 +57,27 @@ export default Table.extend(Validations, {
         set(model, 'attribute', get(model, 'attribute') ?? []);
       });
     }
-  },
+  }
 
-  /**
-   * attrCntType is the alias for 'attributeContentType' used in the validations for the
-   * 'attributeGroup' object.
-   *
-   * @property attrCntType
-   * @type String
-   * @requires alias
-   * @default "alias('model.attrbuteContenType')"
-   */
-  attrCntType: alias('model.attributeContentType'),
-
-  tagName: 'form',
-
-  actions: {
-    /**
-     * 'editAttribute' is an crud action for the 'attributeGroup' object that transitions users to
-     * the 'attribute' route for editing.
-     * @method editAttribute
-     * @param {Number} index
-     */
+  actions = {
     handleEditAttribute(index) {
       if (this.editAttribute) {
         this.editAttribute(index);
       }
     },
-    /**
-     * 'deleteAttribute' is an crud action for the 'attributeGroup' object that deletes 'attribute' objects.
-     * @method deleteAttribute
-     * @param {Number} index
-     */
+
     handleDeleteAttrGroup(index) {
       if (this.deleteAttrGroup) {
         this.deleteAttrGroup(index);
       }
     },
-    /**
-     * 'addAttrGroup' is an crud action for the 'attributeGroup' object that adds 'attribute' objects.
-     * @method addAttrGroup
-     */
+
     handleAddAttrGroup() {
       if (this.addAttrGroup) {
         this.addAttrGroup();
       }
     },
-  },
-});
+  };
+}
 
 export { Validations };

--- a/app/pods/components/object/md-simple-array-table/component.js
+++ b/app/pods/components/object/md-simple-array-table/component.js
@@ -6,51 +6,75 @@ import {
 } from '@ember/object';
 import { A } from '@ember/array';
 import { schedule } from '@ember/runloop';
+import classic from 'ember-classic-decorator';
 import ArrayTable from '../md-array-table/component';
 
-export default ArrayTable.extend({
-  /**
-   * mdEditor component for input and edit of arrays of scalars. The
-   * component is rendered as an editable table.
-   *
-   * ```handlebars
-   * {{#object/md-simple-array-table
-   *   title="Simple"
-   *   required=false
-   *   plain=true
-   *   value=model as |val|
-   * }}
-   *   <td>
-   *       {{input/md-input value=val.item.value
-   *       placeholder="Enter value"}}
-   *   </td>
-   * {{/object/md-simple-array-table}}
-   * ```
-   * @class md-simple-array-table
-   * @module mdeditor
-   * @submodule components-object
-   * @extends md-array-table
-   * @constructor
-   */
+/**
+ * mdEditor component for input and edit of arrays of scalars. The
+ * component is rendered as an editable table.
+ *
+ * ```handlebars
+ * {{#object/md-simple-array-table
+ *   title="Simple"
+ *   required=false
+ *   plain=true
+ *   value=model as |val|
+ * }}
+ *   <td>
+ *     {{input/md-input value=val.item.value placeholder="Enter value"}}
+ *   </td>
+ * {{/object/md-simple-array-table}}
+ * ```
+ *
+ * @class md-simple-array-table
+ * @module mdeditor
+ * @submodule components-object
+ * @extends md-array-table
+ */
+@classic
+class MdSimpleArrayTableComponent extends ArrayTable {
+  layoutName = 'components/object/md-array-table';
 
-  layoutName: 'components/object/md-array-table',
-  simple: true,
+  simple = true;
 
-  /**
-   * Convert the input 'primitive' array to an 'ember' array of objects
-   *
-   * @property arrayValues
-   * @type {Array}
-   * @category computed
-   * @requires value.[]
-   */
+  @action
+  addItem() {
+    if (!this.value) {
+      this.set('value', A());
+    }
+
+    this._suppressObserver = true;
+
+    this.value.pushObject('');
+
+    notifyPropertyChange(this, 'value');
+    notifyPropertyChange(this, 'arrayValues');
+    this.valueChanged();
+
+    schedule('afterRender', this, () => {
+      this._suppressObserver = false;
+    });
+  }
+
+  @action
+  deleteItem(item, idx) {
+    if (this.value && this.value.length > idx) {
+      this.value.removeAt(idx);
+    }
+
+    notifyPropertyChange(this, 'value');
+    notifyPropertyChange(this, 'arrayValues');
+    this.valueChanged();
+  }
+}
+
+MdSimpleArrayTableComponent.reopen({
   arrayValues: computed('value.[]', {
     get() {
       let items = this.value;
 
       if (items === undefined) {
         items = [];
-        //items[0] = '';
       }
 
       return items.reduce(function (acc, value) {
@@ -68,57 +92,12 @@ export default ArrayTable.extend({
     },
   }),
 
-  /**
-   * Set the value when arrayValues is updated
-   *
-   * @property valuesObserver
-   * @type {Observer}
-   * @category computed
-   * @requires arrayValues.@each.value
-   */
   valuesObserver: observer('arrayValues.@each.value', function () {
     if (this._suppressObserver) {
       return;
     }
     this.set('arrayValues', this.arrayValues);
   }),
-
-  /**
-   * Override addItem to push to primitive value array
-   */
-  addItem: action(function () {
-    // Initialize value if it's not set
-    if (!this.value) {
-      this.set('value', A());
-    }
-
-    // Suppress observer so the empty string isn't immediately filtered out
-    this._suppressObserver = true;
-
-    // Push empty string to primitive array
-    this.value.pushObject('');
-
-    // Trigger reactivity
-    notifyPropertyChange(this, 'value');
-    notifyPropertyChange(this, 'arrayValues');
-    this.valueChanged();
-
-    // Re-enable observer after render so user edits sync normally
-    schedule('afterRender', this, () => {
-      this._suppressObserver = false;
-    });
-  }),
-
-  /**
-   * Override deleteItem to remove from primitive value array
-   */
-  deleteItem: action(function (item, idx) {
-    if (this.value && this.value.length > idx) {
-      this.value.removeAt(idx);
-    }
-    // Trigger reactivity
-    notifyPropertyChange(this, 'value');
-    notifyPropertyChange(this, 'arrayValues');
-    this.valueChanged();
-  }),
 });
+
+export default MdSimpleArrayTableComponent;

--- a/app/pods/components/object/md-taxonomy/collection/component.js
+++ b/app/pods/components/object/md-taxonomy/collection/component.js
@@ -35,7 +35,7 @@ const Validations = buildValidations({
 
 const TemplateClass = EmberObject.extend(Validations, {
   init() {
-    this._super(...arguments);
+    super.init(...arguments);
 
     set(this, 'taxonomicSystem', []);
     set(this, 'identificationReference', []);
@@ -50,7 +50,7 @@ const theComp = Component.extend(Validations, {
   editSystem: null,
 
   didReceiveAttrs() {
-    this._super(...arguments);
+    super.didReceiveAttrs(...arguments);
 
     let model = this.model;
 
@@ -96,7 +96,7 @@ const theComp = Component.extend(Validations, {
   taxonomicClassification: alias('model.taxonomicClassification'),
   systemTemplate: EmberObject.extend({
     init() {
-      this._super(...arguments);
+      super.init(...arguments);
       this.set('citation', {});
     },
   }),

--- a/app/pods/components/object/md-taxonomy/collection/component.js
+++ b/app/pods/components/object/md-taxonomy/collection/component.js
@@ -1,4 +1,5 @@
 import Component from '@ember/component';
+import classic from 'ember-classic-decorator';
 import EmberObject, { set, get } from '@ember/object';
 import { alias } from '@ember/object/computed';
 import { once } from '@ember/runloop';
@@ -19,12 +20,6 @@ const Validations = buildValidations({
       ignoreBlank: true,
     }),
   ],
-  // 'identificationProcedure': [
-  //   validator('presence', {
-  //     presence: true,
-  //     ignoreBlank: true
-  //   })
-  // ],
   taxonomicClassification: [
     validator('presence', {
       presence: true,
@@ -35,7 +30,7 @@ const Validations = buildValidations({
 
 const TemplateClass = EmberObject.extend(Validations, {
   init() {
-    super.init(...arguments);
+    this._super(...arguments);
 
     set(this, 'taxonomicSystem', []);
     set(this, 'identificationReference', []);
@@ -45,9 +40,25 @@ const TemplateClass = EmberObject.extend(Validations, {
   },
 });
 
-const theComp = Component.extend(Validations, {
-  // Passed-in action
-  editSystem: null,
+@classic
+export default class MdTaxonomyCollectionComponent extends Component.extend(
+  Validations
+) {
+  tagName = 'form';
+
+  taxonomicSystem = alias('model.taxonomicSystem');
+  title = alias('model.taxonomicSystem.firstObject.citation.title');
+  identificationProcedure = alias('model.identificationProcedure');
+  taxonomicClassification = alias('model.taxonomicClassification');
+
+  voucherTemplate = Voucher;
+
+  systemTemplate = EmberObject.extend({
+    init() {
+      this._super(...arguments);
+      this.set('citation', {});
+    },
+  });
 
   didReceiveAttrs() {
     super.didReceiveAttrs(...arguments);
@@ -69,37 +80,7 @@ const theComp = Component.extend(Validations, {
       set(model, 'observer', get(model, 'observer') ?? []);
       set(model, 'voucher', get(model, 'voucher') ?? []);
     });
-  },
-  voucherTemplate: Voucher,
+  }
+}
 
-  /**
-   * The string representing the path in the profile object for the collection.
-   *
-   * @property profilePath
-   * @type {String}
-   * @default 'false'
-   * @required
-   */
-
-  /**
-   * The object to use as the data model for the collection.
-   *
-   * @property model
-   * @type {Object}
-   * @required
-   */
-
-  tagName: 'form',
-  taxonomicSystem: alias('model.taxonomicSystem'),
-  title: alias('model.taxonomicSystem.firstObject.citation.title'),
-  identificationProcedure: alias('model.identificationProcedure'),
-  taxonomicClassification: alias('model.taxonomicClassification'),
-  systemTemplate: EmberObject.extend({
-    init() {
-      super.init(...arguments);
-      this.set('citation', {});
-    },
-  }),
-});
-
-export { Validations, TemplateClass as Template, theComp as default };
+export { Validations, TemplateClass as Template };

--- a/app/pods/components/object/md-taxonomy/collection/voucher/component.js
+++ b/app/pods/components/object/md-taxonomy/collection/voucher/component.js
@@ -1,5 +1,6 @@
 import EmberObject, { get, set } from '@ember/object';
 import Component from '@ember/component';
+import classic from 'ember-classic-decorator';
 import { alias } from '@ember/object/computed';
 import { once } from '@ember/runloop';
 import { validator, buildValidations } from 'ember-cp-validations';
@@ -21,16 +22,21 @@ const Validations = buildValidations({
 
 const Template = EmberObject.extend(Validations, {
   init() {
-    super.init(...arguments);
+    this._super(...arguments);
     this.set('repository', {});
     this.set('specimen', null);
   },
 });
 
-const theComp = Component.extend(Validations, {
-  classNames: ['form'],
-  specimen: alias('model.specimen'),
-  repository: alias('model.repository'),
+@classic
+export default class MdVoucherComponent extends Component.extend(Validations) {
+  classNames = ['form'];
+
+  specimen = alias('model.specimen');
+  repository = alias('model.repository');
+
+  templateClass = Template;
+
   didReceiveAttrs() {
     super.didReceiveAttrs(...arguments);
 
@@ -40,10 +46,7 @@ const theComp = Component.extend(Validations, {
       set(model, 'repository', get(model, 'repository') ?? {});
       set(model, 'specimen', get(model, 'specimen') ?? null);
     });
-  },
+  }
+}
 
-  //attributeBindings: ['data-spy'],
-  templateClass: Template,
-});
-
-export { Validations, Template, theComp as default };
+export { Validations, Template };

--- a/app/pods/components/object/md-taxonomy/collection/voucher/component.js
+++ b/app/pods/components/object/md-taxonomy/collection/voucher/component.js
@@ -21,7 +21,7 @@ const Validations = buildValidations({
 
 const Template = EmberObject.extend(Validations, {
   init() {
-    this._super(...arguments);
+    super.init(...arguments);
     this.set('repository', {});
     this.set('specimen', null);
   },
@@ -32,7 +32,7 @@ const theComp = Component.extend(Validations, {
   specimen: alias('model.specimen'),
   repository: alias('model.repository'),
   didReceiveAttrs() {
-    this._super(...arguments);
+    super.didReceiveAttrs(...arguments);
 
     let model = this.model;
 

--- a/app/pods/components/object/md-transfer/component.js
+++ b/app/pods/components/object/md-transfer/component.js
@@ -100,7 +100,7 @@ export default class MdTransferComponent extends Component {
   formatTemplate = EmberObject.extend(
     /*Validations, */ {
       init() {
-        super.init(...arguments);
+        this._super(...arguments);
         this.set('formatSpecification', {});
         this.set('formatSpecification.onlineResource', [{}]);
       },

--- a/app/pods/components/object/md-transfer/component.js
+++ b/app/pods/components/object/md-transfer/component.js
@@ -65,43 +65,47 @@ export default class MdTransferComponent extends Component {
   //     });
   //   }
   // }),
-  @alias('model.distributionFormat.firstObject.formatSpecification.title') formatUri;
+  @alias('model.distributionFormat.firstObject.formatSpecification.title')
+  formatUri;
 
   get timeUnit() {
-    return [{
+    return [
+      {
         name: 'year',
-        value: 'year'
+        value: 'year',
       },
       {
         name: 'month',
-        value: 'month'
+        value: 'month',
       },
       {
         name: 'day',
-        value: 'day'
+        value: 'day',
       },
       {
         name: 'hour',
-        value: 'hour'
+        value: 'hour',
       },
       {
         name: 'minute',
-        value: 'minute'
+        value: 'minute',
       },
       {
         name: 'second',
-        value: 'second'
-      }
+        value: 'second',
+      },
     ];
   }
 
-  formatTemplate = EmberObject.extend( /*Validations, */ {
-    init() {
-      this._super(...arguments);
-      this.set('formatSpecification', {});
-      this.set('formatSpecification.onlineResource', [{}]);
+  formatTemplate = EmberObject.extend(
+    /*Validations, */ {
+      init() {
+        super.init(...arguments);
+        this.set('formatSpecification', {});
+        this.set('formatSpecification.onlineResource', [{}]);
+      },
     }
-  });
+  );
 
   didReceiveAttrs() {
     super.didReceiveAttrs(...arguments);

--- a/app/pods/contact/new/route.js
+++ b/app/pods/contact/new/route.js
@@ -2,7 +2,7 @@ import Route from '@ember/routing/route';
 
 export default class NewRoute extends Route {
   init() {
-    this._super(...arguments);
+    super.init(...arguments);
 
     this.breadCrumb = {
       title: 'New',

--- a/app/pods/contact/route.js
+++ b/app/pods/contact/route.js
@@ -2,7 +2,7 @@ import Route from '@ember/routing/route';
 
 export default class ContactRoute extends Route {
   init() {
-    this._super(...arguments);
+    super.init(...arguments);
 
     this.breadCrumb = {
       title: 'Contact',

--- a/app/pods/contact/show/edit/route.js
+++ b/app/pods/contact/show/edit/route.js
@@ -5,11 +5,11 @@ export default class EditRoute extends Route {
   @service hashPoll;
 
   afterModel(model) {
-    this._super(...arguments);
+    super.afterModel(...arguments);
     this.hashPoll.startPolling(model);
   }
   deactivate() {
-    this._super(...arguments);
+    super.deactivate(...arguments);
     this.hashPoll.stopPolling();
   }
 }

--- a/app/pods/dictionary/new/route.js
+++ b/app/pods/dictionary/new/route.js
@@ -2,7 +2,7 @@ import Route from '@ember/routing/route';
 
 export default class NewRoute extends Route {
   init() {
-    this._super(...arguments);
+    super.init(...arguments);
 
     this.breadCrumb = {
       title: 'New',

--- a/app/pods/dictionary/route.js
+++ b/app/pods/dictionary/route.js
@@ -2,7 +2,7 @@ import Route from '@ember/routing/route';
 
 export default class DictionaryRoute extends Route {
   init() {
-    this._super(...arguments);
+    super.init(...arguments);
 
     this.breadCrumb = {
       title: 'Dictionary',

--- a/app/pods/dictionary/show/edit/domain/edit/citation/route.js
+++ b/app/pods/dictionary/show/edit/domain/edit/citation/route.js
@@ -2,7 +2,7 @@ import Route from '@ember/routing/route';
 
 export default class CitationRoute extends Route {
   init() {
-    this._super(...arguments);
+    super.init(...arguments);
 
     this.breadCrumb = {
       title: 'Reference'

--- a/app/pods/dictionary/show/edit/domain/route.js
+++ b/app/pods/dictionary/show/edit/domain/route.js
@@ -2,7 +2,7 @@ import Route from '@ember/routing/route';
 
 export default class DomainRoute extends Route {
   init() {
-    this._super(...arguments);
+    super.init(...arguments);
 
     this.breadCrumb = {
       title: 'Domains'

--- a/app/pods/not-found/route.js
+++ b/app/pods/not-found/route.js
@@ -10,7 +10,7 @@ export default class NotFoundRoute extends Route {
     });
   }
   init() {
-    this._super(...arguments);
+    super.init(...arguments);
 
     this.breadCrumb = {
       title: 'Page Not Found',

--- a/app/pods/record/index/route.js
+++ b/app/pods/record/index/route.js
@@ -2,7 +2,7 @@ import Route from '@ember/routing/route';
 
 export default class IndexRoute extends Route {
   init() {
-    this._super(...arguments);
+    super.init(...arguments);
 
     this.breadCrumb = {
       title: 'Record',

--- a/app/pods/record/new/id/route.js
+++ b/app/pods/record/new/id/route.js
@@ -42,8 +42,7 @@ export default class IdRoute extends Route {
   }
   //some test actions
   setupController(controller, model) {
-    // Call _super for default behavior
-    this._super(controller, model);
+    super.setupController(controller, model);
   }
   // serialize(model) {
   //   // If we got here without an ID (and therefore without a model)

--- a/app/pods/record/new/route.js
+++ b/app/pods/record/new/route.js
@@ -2,7 +2,7 @@ import Route from '@ember/routing/route';
 
 export default class NewRoute extends Route {
   init() {
-    this._super(...arguments);
+    super.init(...arguments);
 
     this.breadCrumb = {
       title: 'New',

--- a/app/pods/record/route.js
+++ b/app/pods/record/route.js
@@ -2,7 +2,7 @@ import Route from '@ember/routing/route';
 
 export default class RecordRoute extends Route {
   init() {
-    this._super(...arguments);
+    super.init(...arguments);
 
     this.breadCrumb = {
       title: 'Record',

--- a/app/pods/record/show/edit/associated/index/route.js
+++ b/app/pods/record/show/edit/associated/index/route.js
@@ -11,11 +11,10 @@ export default class IndexRoute extends Route {
     let model = get(m, 'json.metadata');
     set(model, 'associatedResource', get(model, 'associatedResource') ?? []);
   }
-  setupController() {
-    // Call _super for default behavior
-    super.setupController(...arguments);
+  setupController(controller, model) {
+    super.setupController(controller, model);
 
-    this.controller.set('parentModel', this.modelFor('record.show.edit'));
+    controller.set('parentModel', this.modelFor('record.show.edit'));
   }
 
   @action

--- a/app/pods/record/show/edit/dataquality/edit/index/route.js
+++ b/app/pods/record/show/edit/dataquality/edit/index/route.js
@@ -1,15 +1,14 @@
 import Route from '@ember/routing/route';
-import { get } from '@ember/object';
 import ScrollTo from 'mdeditor/mixins/scroll-to';
 
 export default class IndexRoute extends Route.extend(ScrollTo) {
-  setupController() {
-    // Call _super for default behavior
-    this._super(...arguments);
+  setupController(controller, model) {
+    super.setupController(controller, model);
 
-    this.controller.set('parentModel', this.modelFor(
-      'record.show.edit.main'));
-    this.controller.set('dataQualityId', get(this.controllerFor(
-      'record.show.edit.dataquality.edit'), 'dataQualityId'));
+    controller.setProperties({
+      parentModel: this.modelFor('record.show.edit.main'),
+      dataQualityId: this.paramsFor('record.show.edit.dataquality.edit')
+        .data_quality_id,
+    });
   }
 }

--- a/app/pods/record/show/edit/documents/citation/index/route.js
+++ b/app/pods/record/show/edit/documents/citation/index/route.js
@@ -1,15 +1,14 @@
 import Route from '@ember/routing/route';
-import { get } from '@ember/object';
 import ScrollTo from 'mdeditor/mixins/scroll-to';
 
 export default class IndexRoute extends Route.extend(ScrollTo) {
-  setupController() {
-    // Call _super for default behavior
-    this._super(...arguments);
+  setupController(controller, model) {
+    super.setupController(controller, model);
 
-    this.controller.set('parentModel', this.modelFor(
-      'record.show.edit'));
-    this.controller.set('citationId', get(this.controllerFor(
-      'record.show.edit.documents.citation'), 'citationId'));
+    controller.setProperties({
+      parentModel: this.modelFor('record.show.edit'),
+      citationId: this.paramsFor('record.show.edit.documents.citation')
+        .citation_id,
+    });
   }
 }

--- a/app/pods/record/show/edit/lineage/index/route.js
+++ b/app/pods/record/show/edit/lineage/index/route.js
@@ -12,11 +12,10 @@ export default class IndexRoute extends Route {
     let model = get(m, 'json.metadata');
     set(model, 'resourceLineage', get(model, 'resourceLineage') ?? []);
   }
-  setupController() {
-    // Call _super for default behavior
-    super.setupController(...arguments);
+  setupController(controller, model) {
+    super.setupController(controller, model);
 
-    this.controller.set('parentModel', this.modelFor('record.show.edit'));
+    controller.set('parentModel', this.modelFor('record.show.edit'));
   }
 
   @action

--- a/app/pods/record/show/edit/main/citation/identifier/route.js
+++ b/app/pods/record/show/edit/main/citation/identifier/route.js
@@ -12,11 +12,10 @@ export default class IdentifierRoute extends Route.extend(ScrollTo) {
 
     return this.setupModel();
   }
-  setupController() {
-    // Call _super for default behavior
-    this._super(...arguments);
+  setupController(controller, model) {
+    super.setupController(controller, model);
 
-    this.controller.set('parentModel', this.modelFor('record.show.edit.main'));
+    controller.set('parentModel', this.modelFor('record.show.edit.main'));
     this.controllerFor('record.show.edit').setProperties({
       onCancel: this.setupModel,
       cancelScope: this,

--- a/app/pods/record/show/edit/metadata/alternate/identifier/route.js
+++ b/app/pods/record/show/edit/metadata/alternate/identifier/route.js
@@ -14,11 +14,10 @@ export default class IdentifierRoute extends Route.extend(ScrollTo) {
 
     return this.setupModel();
   }
-  setupController() {
-    // Call _super for default behavior
-    this._super(...arguments);
+  setupController(controller, model) {
+    super.setupController(controller, model);
 
-    this.controller.set('parentModel', this.modelFor('record.show.edit'));
+    controller.set('parentModel', this.modelFor('record.show.edit'));
     this.controllerFor('record.show.edit').setProperties({
       onCancel: this.setupModel,
       cancelScope: this,

--- a/app/pods/record/show/edit/metadata/alternate/route.js
+++ b/app/pods/record/show/edit/metadata/alternate/route.js
@@ -12,11 +12,10 @@ export default class AlternateRoute extends Route {
 
     return this.setupModel();
   }
-  setupController() {
-    // Call _super for default behavior
-    this._super(...arguments);
+  setupController(controller, model) {
+    super.setupController(controller, model);
 
-    this.controller.set('parentModel', this.modelFor('record.show.edit'));
+    controller.set('parentModel', this.modelFor('record.show.edit'));
     this.controllerFor('record.show.edit').setProperties({
       onCancel: this.setupModel,
       cancelScope: this,

--- a/app/pods/record/show/edit/metadata/identifier/route.js
+++ b/app/pods/record/show/edit/metadata/identifier/route.js
@@ -1,16 +1,14 @@
 import Route from '@ember/routing/route';
-import { get } from '@ember/object';
 import ScrollTo from 'mdeditor/mixins/scroll-to';
 
 export default class IdentifierRoute extends Route.extend(ScrollTo) {
   model() {
     return this.setupModel();
   }
-  setupController() {
-    // Call _super for default behavior
-    this._super(...arguments);
+  setupController(controller, model) {
+    super.setupController(controller, model);
 
-    this.controller.set('parentModel', this.modelFor('record.show.edit'));
+    controller.set('parentModel', this.modelFor('record.show.edit'));
     this.controllerFor('record.show.edit').setProperties({
       onCancel: this.setupModel,
       cancelScope: this,

--- a/app/pods/record/show/edit/metadata/parent/identifier/route.js
+++ b/app/pods/record/show/edit/metadata/parent/identifier/route.js
@@ -12,11 +12,10 @@ export default class IdentifierRoute extends Route.extend(ScrollTo) {
 
     return this.setupModel();
   }
-  setupController() {
-    // Call _super for default behavior
-    this._super(...arguments);
+  setupController(controller, model) {
+    super.setupController(controller, model);
 
-    this.controller.set('parentModel', this.modelFor('record.show.edit'));
+    controller.set('parentModel', this.modelFor('record.show.edit'));
     this.controllerFor('record.show.edit').setProperties({
       onCancel: this.setupModel,
       cancelScope: this,

--- a/app/pods/record/show/edit/metadata/parent/index/route.js
+++ b/app/pods/record/show/edit/metadata/parent/index/route.js
@@ -9,7 +9,7 @@ export default class IndexRoute extends Route.extend(ScrollTo) {
   @service flashMessages;
   @service router;
   afterModel(model) {
-    this._super(...arguments);
+    super.afterModel(...arguments);
 
     if(isNone(get(model, 'json.metadata.metadataInfo.parentMetadata'))) {
       this.flashMessages

--- a/app/pods/record/show/edit/spatial/raster/index/route.js
+++ b/app/pods/record/show/edit/spatial/raster/index/route.js
@@ -1,20 +1,18 @@
 import Route from '@ember/routing/route';
-import { get, defineProperty } from '@ember/object';
+import { defineProperty } from '@ember/object';
 import { alias } from '@ember/object/computed';
 
 export default class IndexRoute extends Route {
-  setupController() {
-    // Call _super for default behavior
-    this._super(...arguments);
+  setupController(controller, model) {
+    super.setupController(controller, model);
 
-    this.controller.set('parentModel', this.modelFor('record.show.edit'));
-    this.controller.set(
-      'rasterId',
-      get(this.controllerFor('record.show.edit.spatial.raster'), 'rasterId')
-    );
+    controller.setProperties({
+      parentModel: this.modelFor('record.show.edit'),
+      rasterId: this.paramsFor('record.show.edit.spatial.raster').raster_id,
+    });
 
     defineProperty(
-      this.controller,
+      controller,
       'refreshSpy',
       alias('model.json.metadata.resourceInfo.coverageDescription.length')
     );

--- a/app/pods/record/show/edit/taxonomy/collection/itis/route.js
+++ b/app/pods/record/show/edit/taxonomy/collection/itis/route.js
@@ -7,7 +7,7 @@ export default class ItisRoute extends Route {
   @service router;
 
   init() {
-    this._super(...arguments);
+    super.init(...arguments);
 
     this.breadCrumb = {
       title: 'ITIS',

--- a/app/pods/record/show/edit/taxonomy/collection/system/route.js
+++ b/app/pods/record/show/edit/taxonomy/collection/system/route.js
@@ -14,11 +14,10 @@ export default class SystemRoute extends Route {
 
     return this.setupModel();
   }
-  setupController() {
-    // Call _super for default behavior
-    this._super(...arguments);
+  setupController(controller, model) {
+    super.setupController(controller, model);
 
-    this.controller.set('parentModel', this.modelFor('record.show.edit'));
+    controller.set('parentModel', this.modelFor('record.show.edit'));
     this.controllerFor('record.show.edit')
       .setProperties({
         onCancel: this.setupModel,

--- a/docs/upgrades/ember-3.28-to-4.0.md
+++ b/docs/upgrades/ember-3.28-to-4.0.md
@@ -4,8 +4,7 @@
 
 - **Source LTS**: Ember 3.28 (ember-source, ember-cli, ember-data all `~3.28.0`)
 - **Target LTS**: Ember 4.12
-- **Migration branch**: `dvonanderson/feature/push-to-ember-4`
-- **Extended branch**: `dvonanderson/feature/push-to-ember-4-1-2`
+- **Migration branch**: `ember-migration` (prep on 3.28, then merge to `develop`)
 - **Tool**: [`ember-cli-update`](https://github.com/ember-cli/ember-cli-update) — run at each version step to apply config/blueprint diffs
 
 ---
@@ -37,22 +36,34 @@
 
 ---
 
-### 2. `this._super()` broken in route lifecycle methods
+### 2. `this._super()` vs `super.methodName()` — when to use which
 
-**What broke**: `this._super()` only works in `init()` because `CoreObject` wraps it. In Ember 4 native class syntax, route lifecycle hooks (`setupController`, `afterModel`, `model`, etc.) must use `super`.
+**Classic `.extend()`** (`Model.extend`, `Component.extend`, `EmberObject.extend`, `Indicator.extend`, etc.):
 
-**Fix**: ~37 route files changed:
+- Always use **`this._super(...arguments)`** in every hook, including `init`.
+- **Do not** use `super.init(...arguments)` — it throws `(intermediate value).init is not a function` because `.extend()` is not a real ES6 class hierarchy.
+- Applies to `app/models/*`, nested `templateClass = EmberObject.extend({ ... })`, and addons such as `control/md-indicator/related`.
+
+**Native classes** (`export default class Foo extends Route` / `@classic class Foo extends Component`):
+
+- Use **`super.methodName(...arguments)`** for lifecycle hooks (`init`, `setupController`, `afterModel`, `didReceiveAttrs`, `willDestroy`, etc.).
+- On Ember 4, `this._super()` in non-`init` hooks on native classes is unreliable; prefer `super` for those routes and components.
+
+**Examples**:
+
 ```js
-// Before
-setupController(controller, model) {
-  this._super(...arguments);
-  // ...
-}
+// Classic model — keep _super on 3.28 and in init on Ember 4
+const Setting = Model.extend({
+  init() {
+    this._super(...arguments);
+  },
+});
 
-// After
-setupController(controller, model) {
-  super.setupController(...arguments);
-  // ...
+// Native route — use super for lifecycle hooks
+export default class ContactRoute extends Route {
+  setupController(controller, model) {
+    super.setupController(controller, model);
+  }
 }
 ```
 

--- a/tests/integration/pods/components/control/md-indicator/related/component-test.js
+++ b/tests/integration/pods/components/control/md-indicator/related/component-test.js
@@ -2,6 +2,7 @@ import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render, triggerEvent, click } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
+import EmberObject from '@ember/object';
 import { createDictionary } from 'mdeditor/tests/helpers/create-dictionary';
 import { assertTooltipContent } from 'ember-tooltips/test-support/dom';
 import Service from '@ember/service';
@@ -16,12 +17,12 @@ module('Integration | Component | control/md-indicator/related', function (
         assert.ok(true, 'Transition started');
       },
       generateURL(route, models) {
-        assert.equal(route, 'dictionary.show.edit.entity', 'route OK');
-        assert.deepEqual(models, ['attribute1'], 'model ids OK');
-      }
+        assert.equal(route, 'dictionary.show.edit.domain.edit', 'route OK');
+        assert.deepEqual(models, [0], 'model ids OK');
+        return '#';
+      },
     });
     this.owner.register('service:-routing', router);
-    //this.router=router;
     this.owner.setupRouter();
   });
 
@@ -33,16 +34,16 @@ module('Integration | Component | control/md-indicator/related', function (
       bar: 'codeName0',
     });
 
-    this.set('dictionary', createDictionary(1)[0].json
-      .dataDictionary);
+    this.set('dictionary', EmberObject.create(
+      createDictionary(1)[0].json.dataDictionary
+    ));
     this.set('model', this.dictionary.entity[0].attribute[0]);
 
     await render(hbs `{{control/md-indicator/related
       model=model
-      route=true
       icon="cog"
       note="The attribute \${foo} has an associated domain: \${bar}."
-      route="dictionary.show.edit.entity"
+      route="dictionary.show.edit.domain.edit"
       values=values
       parent=dictionary
       relatedId="domainId"
@@ -51,14 +52,13 @@ module('Integration | Component | control/md-indicator/related', function (
       linkText="Go to Domain"
       type="warning"
       popperContainer="#ember-testing"
-      routeIdPaths=(array "values.foo")
+      routeIdPaths=(array "relatedIndex")
     }}`);
 
-    assert.dom('.md-indicator-related .md-indicator').isVisible({ count: 1 });
-    assert.dom('.md-indicator .fa').hasClass('fa-cog');
+    assert.dom('.md-indicator-related').exists({ count: 1 });
+    assert.dom('.md-indicator-related .fa').hasClass('fa-cog');
 
-    await triggerEvent('.md-indicator-related .md-indicator',
-      'mouseenter');
+    await triggerEvent('.md-indicator-related .fa', 'mouseenter');
 
     assertTooltipContent(assert, {
       contentString: `Related Indicator Test\nThe attribute attribute1 has an associated domain: codeName0.\nGo to Domain`

--- a/tests/integration/pods/components/input/md-input/component-test.js
+++ b/tests/integration/pods/components/input/md-input/component-test.js
@@ -2,6 +2,7 @@ import { find, render } from '@ember/test-helpers';
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
+import EmberObject from '@ember/object';
 
 module('Integration | Component | input/md input', function(hooks) {
   setupRenderingTest(hooks);
@@ -40,5 +41,21 @@ module('Integration | Component | input/md input', function(hooks) {
     `);
 
     assert.equal(find('.help-block').textContent, 'help text', 'block renders');
+  });
+
+  test('it accepts required when bound to a model', async function(assert) {
+    this.set('model', EmberObject.create({ title: 'Hello' }));
+
+    await render(hbs`
+      {{input/md-input
+        model=this.model
+        valuePath="title"
+        label="Title"
+        required=true
+      }}
+    `);
+
+    assert.dom('input').hasAttribute('required');
+    assert.dom('.md-input').hasClass('required');
   });
 });


### PR DESCRIPTION
Summary
Prepares mdEditor for the Ember 4.x upgrade by converting classic export default X.extend({...}) components to @classic native classes, fixing template and lifecycle patterns that break under Ember 4, and addressing runtime regressions found during migration. Also includes earlier ember-migration work (explicit this. in templates, route/controller refactors, addon patches, and bug fixes merged from related branches).

This is a large branch (~873 files vs develop). The core theme is Ember 3.28 → 4.x prep on 3.28, not a version bump yet.

Component migration (.extend() → native @classic classes)
Converted 169 component modules from classic .extend() to @classic native classes, including:

Control: md-indicator, md-indicator/related, md-record-table, md-select-table, md-fiscalyear, and others
Input: md-input, md-textarea, md-select, md-codelist-multi, md-select-contact, md-select-contacts, and others
Object/layout: md-simple-array-table, md-identifier-object-table, md-raster/attrgroup, and many more
No remaining export default X.extend({ under app/pods/components (except intentional Component.extend(Validations) mixin usage on validated object forms).

Migration patterns used
super.init(...arguments) in native class lifecycle hooks (not this._super)
reopen() for classic computed() / observer() / actions when overriding parent behavior or merging like .extend() did — e.g. md-codelist-multi, md-select-table, md-indicator/related
defineProperty before super.init() when parent init reads overridden CPs (e.g. md-record-table columns)
classNames merged on prototype when native subclass would otherwise replace parent classes
Runtime bug fixes (migration regressions)
input/md-input, md-textarea, md-select: Fixed crash Cannot set read-only property "required" when templates pass required=true alongside model + valuePath. Validation-derived required is now a computed with a setter that stores an explicit override.
control/md-indicator/related: Converted from broken Indicator.extend() (native parent) to @classic extends Indicator + reopen(); replaced broken map() macro for models with an explicit computed; updated integration test (relatedIndex route pattern, generateURL stub).
Broader branch changes (from ember-migration lineage)
Templates: ~250 bare property references updated to this. for Ember 4 this-property-fallback removal
Templates: {{#with}} → {{#let}} / {{#if}} (~40 files)
Routes/controllers: no-route-action lint fixes; explicit @service injections; native route classes with super.setupController() etc.
Addons/infra: Yarn patches (ember-pouch, ember-in-element-polyfill), dependency pins, ember-cli-template-lint removal, upgrade docs in docs/upgrades/
Misc bug fixes: fiscal year save, identifier panels, checkboxes/tables, ITIS proxy, ScienceBase publish, taxa import, and others merged along the way
Intentionally deferred
Component.extend(Validations) on ~33 object form components (e.g. md-entity, md-attribute, md-domain) — keep classic mixin + this._super until Ember 4 bump
Models, services, routes still using .extend() where documented
object/md-attribute integration test (and ~10 similar object-form tests) still failing — render error under investigation, not yet fixed
Test plan

 Record edit main page loads without required read-only errors (Title, Status, Abstract, etc.)

 Dictionary attribute/entity forms render related indicators and validated inputs

 ember test --filter="control/md-indicator"

 ember test --filter="input/md input"

 Full suite: 388 pass / 11 fail — failures cluster around object/md-* validated form integration tests and input/md-month

 ember build (production)