### PR TITLE
BUG: Fix sync page regression from Ember 4 migration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ jsconfig.json
 .playwright/*
 .DS_Store
 .vscode
+.claude/
 
 .yarn/*
 yarn.lock.ember-try

--- a/app/pods/components/control/md-couch-login/component.js
+++ b/app/pods/components/control/md-couch-login/component.js
@@ -2,7 +2,6 @@ import Component from '@glimmer/component';
 import { inject as service } from '@ember/service';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
-import { scheduleOnce } from '@ember/runloop';
 
 export default class CouchLoginComponent extends Component {
   @service couch;
@@ -14,8 +13,6 @@ export default class CouchLoginComponent extends Component {
   // DB data
   @tracked remoteUrl = null;
   @tracked remoteName = null;
-  // Internal tracking
-  _defaultsScheduled = false;
 
   constructor() {
     super(...arguments);
@@ -23,66 +20,67 @@ export default class CouchLoginComponent extends Component {
     this.loadDefaults();
   }
 
-  loadDefaults() {
-    if (this.settings.data && !this.couch.loggedIn) {
-      const rawOptions = this.settings.data.publishOptions;
-      const publishOptions = Array.isArray(rawOptions) ? rawOptions : [];
-      // Support both legacy 'catalog' field and new 'publisher' field
-      const couchdbSettings = publishOptions.find(
-        (option) =>
-          option.catalog === 'CouchDB' || option.publisher === 'CouchDB'
-      );
+  async loadDefaults() {
+    // The settings record loads asynchronously and may not be ready yet
+    // (e.g. on a fresh page load of the sync route)
+    if (!this.settings.data) {
+      await this.settings.ready;
+    }
 
-      if (couchdbSettings) {
-        // Only set defaults if fields are empty to avoid overwriting user input
-        if (!this.remoteUrl) {
-          this.remoteUrl =
-            couchdbSettings.publisherEndpoint ||
-            couchdbSettings['couchdb-url'] ||
-            null;
-        }
-        if (!this.remoteName) {
-          this.remoteName = couchdbSettings['couchdb-database'] || null;
-        }
-        if (!this.username) {
-          this.username = couchdbSettings['couchdb-username'] || null;
-        }
+    if (!this.settings.data || this.couch.loggedIn) {
+      return;
+    }
+
+    const rawOptions = this.settings.data.publishOptions;
+    const publishOptions = Array.isArray(rawOptions) ? rawOptions : [];
+    // Support both legacy 'catalog' field and new 'publisher' field
+    const couchdbSettings = publishOptions.find(
+      (option) =>
+        option.catalog === 'CouchDB' || option.publisher === 'CouchDB'
+    );
+
+    if (couchdbSettings) {
+      // Only set defaults if fields are empty to avoid overwriting user input
+      if (!this.remoteUrl) {
+        this.remoteUrl =
+          couchdbSettings.publisherEndpoint ||
+          couchdbSettings['couchdb-url'] ||
+          null;
+      }
+      if (!this.remoteName) {
+        this.remoteName = couchdbSettings['couchdb-database'] || null;
+      }
+      if (!this.username) {
+        this.username = couchdbSettings['couchdb-username'] || null;
       }
     }
   }
 
-  get settingsAvailable() {
-    // Non-reactive getter to check if settings are loaded
-    const hasSettings = !!this.settings.data;
-
-    // Schedule defaults loading for next run loop to avoid revalidation
-    if (hasSettings && !this.couch.loggedIn && !this._defaultsScheduled) {
-      this._defaultsScheduled = true;
-      scheduleOnce('afterRender', this, 'loadDefaults');
-    }
-
-    return hasSettings;
-  }
-
   @action
-  login() {
-    this.couch.login(
+  async login() {
+    await this.couch.login(
       this.remoteUrl,
       this.remoteName,
       this.username,
       this.password
     );
-    this.username = null;
-    this.password = null;
-    this.remoteUrl = null;
-    this.remoteName = null;
+    if (this.couch.loggedIn) {
+      this.username = null;
+      this.password = null;
+      this.remoteUrl = null;
+      this.remoteName = null;
+    } else {
+      // Login failed - clear only the password, keep the rest so the
+      // user doesn't have to re-enter (or wait for) their settings defaults
+      this.password = null;
+    }
   }
 
   @action
   logout() {
     this.couch.logout();
-    // Reset scheduling flag so defaults can be loaded again
-    this._defaultsScheduled = false;
+    // Fields are empty again after logout - refill them from settings
+    this.loadDefaults();
   }
 
   @action

--- a/app/pods/components/control/md-pouch-add/template.hbs
+++ b/app/pods/components/control/md-pouch-add/template.hbs
@@ -21,7 +21,7 @@
       <button
         class='btn btn-md btn-success'
         type='button'
-        {{on 'click' (fn this.savenew @section.meta.type)}}
+        {{on 'click' (fn this.saveNew @section.meta.type)}}
       >
         {{fa-icon 'floppy-o'}}
         Save
@@ -33,7 +33,7 @@
         <button
           class='btn btn-lg btn-primary'
           type='button'
-          {{on 'click' (fn this.savenew @section.meta.type)}}
+          {{on 'click' this.addNew}}
         >
           {{fa-icon 'plus'}}
           Add new

--- a/app/pods/sync/list/template.hbs
+++ b/app/pods/sync/list/template.hbs
@@ -18,7 +18,7 @@
 
           <Control::MdPouchRecordTable
             @data={{section}}
-            @dataColumns={{section.meta.columns}}
+            @columns={{section.meta.columns}}
           />
         </Layout::MdCard>
       {{else}}

--- a/app/services/settings.js
+++ b/app/services/settings.js
@@ -17,6 +17,12 @@ export default Service.extend({
 
     this.setup();
   },
+
+  // Resolves once the initial settings record has loaded (or been created)
+  get ready() {
+    return this._setupPromise;
+  },
+
   setup() {
     let me = this;
     let store = this.store;


### PR DESCRIPTION
closes #863 
 # Summary

  - Fixed `Control::MdPouchAdd` throwing Uncaught Error: You must pass a function as the `fn` helper's first argument when opening the Sync menu with records loaded — the template called `this.savenew` but the component defines saveNew (case mismatch, app/pods/components/control/md-pouch-add/template.hbs).
  - Fixed "Add new record/contact/dictionary" throwing Expected id to be a string or number, received null — the button
  invoked `saveNew` directly instead of `addNew`, so it tried to save before the user had picked a record from the dropdown.
  - Fixed the Pouch Metadata Records / Contacts / Dictionaries tables rendering with correct row counts but blank headers
  and cells — the angle-bracket conversion of `Control::MdPouchRecordTable` renamed `columns=... to @dataColumns=`..., but that component extends ember-models-table's ModelsTable directly, which only recognizes @columns (app/pods/sync/list/template.hbs).
  - Fixed CouchDB login fields (URL/Name/Username) getting wiped out after a failed login attempt, and fixed them sometimes failing to pre-populate from Settings at all on a fresh page load (app/pods/components/control/md-couch-login/component.js, app/services/settings.js):
    - login() now awaits the login call and only clears all fields on success; on failure it clears just the password.
    - Replaced a non-reactive settingsAvailable getter (dead code — never referenced in the template, and read a
  `non-@tracked` property so it wouldn't re-run anyway) with an explicit await this.settings.ready in `loadDefaults()`, using a
  new ready getter exposing the settings service's internal setup promise.
    - `logout()` now calls `loadDefaults()` directly to refill the form instead of relying on the broken scheduling flag.

  ## Why

  All four bugs were introduced during the Ember 3→4 migration's curly-to-angle-bracket template conversion and Glimmer
  component rewrites — none are new behavior changes, just restoring parity with the pre-migration app.

  Test plan

  - [x] Verified in-browser via l`ocalhost:4200/sync/list`: menu opens without error when records are loaded.
  - [x] Verified "Add new contact" reveals the picker instead of erroring.
  - [x] Verified Pouch Metadata Records / Contacts tables render headers and row data.
  - [x] Verified CouchDB login form pre-populates URL/Name/Username from Settings on fresh load.
  - [x] Verified a failed login attempt clears only the password, keeping URL/Name/Username intact.
  - [ ] Manual smoke test against a real CouchDB instance (successful login/logout cycle) recommended before merge.