### PR TITLE
BUG: Fix dashboard selected button

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ jsconfig.json
 .playwright/*
 .DS_Store
 .vscode
+.claude/
 
 .yarn/*
 yarn.lock.ember-try

--- a/app/pods/components/control/md-record-table/buttons/filter/component.js
+++ b/app/pods/components/control/md-record-table/buttons/filter/component.js
@@ -1,4 +1,5 @@
 import { inject as service } from '@ember/service';
+import { computed } from '@ember/object';
 import classic from 'ember-classic-decorator';
 import Component from '@ember/component';
 import { once } from '@ember/runloop';
@@ -7,6 +8,11 @@ import { once } from '@ember/runloop';
 export default class FilterComponent extends Component {
   @service flashMessages;
 
+  // `selectedItems` is a live array mutated in place (pushObject/removeObject)
+  // by ember-models-table, not replaced - so this must be a real computed
+  // property with an explicit '.[]' dependent key. A plain getter is never
+  // re-evaluated by classic (curly) components once mounted.
+  @computed('selectedItems.[]')
   get showButton() {
     return this.selectedItems?.length >= 1;
   }
@@ -20,13 +26,14 @@ export default class FilterComponent extends Component {
 
   _deleteSelected(records) {
     records.forEach((rec) => {
+      const modelName = rec.constructor.modelName;
+      const title = rec.get('title');
+
       rec.destroyRecord().then((rec) => {
         rec.unloadRecord();
         once(() => {
           records.removeObject(rec);
-          this.flashMessages.danger(
-            `Deleted ${rec.constructor.modelName} "${rec.get('title')}".`
-          );
+          this.flashMessages.danger(`Deleted ${modelName} "${title}".`);
         });
       });
     });


### PR DESCRIPTION
closes #862 

# Summary

  Two bugs in `Control::MdRecordTable::Buttons::Filter` (the header cell that renders the bulk "Delete Selected" action on the Records/Contacts/Dictionaries dashboards):

  1. "Delete Selected" never appeared, even with multiple rows selected. `showButton` was a plain native getter reading
  `this.selectedItems?.length. selectedItems` is a live array that ember-models-table mutates in place (pushObject/removeObject) rather than replacing — and for classic (curly) Ember components, template reactivity depends
  entirely on explicit dependent-key tracking. A bare getter is evaluated once at mount and never re-invoked, so the
  button's visibility got stuck at its initial (empty-selection) state. Fixed by decorating the getter with @computed('selectedItems.[]').
  2. Flash message read Deleted record "undefined" instead of the record's title. In `_deleteSelected`, `rec.get('title')` was
  read after `rec.unloadRecord()` — once a record is unloaded its attributes are gone, so title always came back undefined.
  Fixed by capturing `modelName` and title before `destroyRecord()`/`unloadRecord()` run, and using those captured values in the flash message.

  ## Why

  Both were introduced/exposed as part of the Ember migration work on this branch; neither is a new behavior change, just
  restoring the pre-migration UX.

  Test plan

  - [x] Verified in-browser on /contacts: selecting 2 rows shows "Delete Selected"; deselecting back to 0 hides it;
  selecting 1 keeps it visible (matches existing >= 1 threshold).
  - [x] Verified bulk delete confirm flow end-to-end; flash messages now correctly read e.g. Deleted contact "Jared 
  Laufenberg". instead of "undefined".
  - [x] No console errors during selection or delete.
  - [x] Recommend a quick manual pass on the Records and Dictionaries dashboards too, since they share this same component.