### PR TITLE
Scaffold Playwright E2E testing

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -71,10 +71,12 @@ module.exports = {
         '.stylelintrc.js',
         'ember-cli-build.js',
         'testem.js',
+        'playwright.config.js',
         'blueprints/*/index.js',
         'config/**/*.js',
         'lib/*/index.js',
         'server/**/*.js',
+        'e2e/**/*.js',
       ],
       parserOptions: {
         sourceType: 'script',

--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,8 @@ jsconfig.json
 /package.json.ember-try
 /mdeditor-test-fullset-20211206.json
 .playwright/*
+/playwright-report/
+/test-results/
 .DS_Store
 .vscode
 .claude/

--- a/e2e/smoke.spec.js
+++ b/e2e/smoke.spec.js
@@ -1,0 +1,21 @@
+const { test, expect } = require('@playwright/test');
+
+test.describe('smoke', () => {
+  test('dashboard loads and shows the summary cards', async ({ page }) => {
+    await page.goto('/dashboard');
+
+    await expect(page).toHaveTitle(/mdEditor/);
+    await expect(page.getByRole('link', { name: 'View Records' })).toBeVisible();
+    await expect(page.getByRole('link', { name: 'View Contacts' })).toBeVisible();
+    await expect(page.getByRole('link', { name: 'View Dictionaries' })).toBeVisible();
+  });
+
+  test('top nav links to the main sections', async ({ page }) => {
+    await page.goto('/dashboard');
+
+    await expect(page.getByRole('link', { name: 'Export' })).toBeVisible();
+    await expect(page.getByRole('link', { name: 'Import' })).toBeVisible();
+    await expect(page.getByRole('link', { name: 'Publish' })).toBeVisible();
+    await expect(page.getByRole('link', { name: 'Sync' })).toBeVisible();
+  });
+});

--- a/package.json
+++ b/package.json
@@ -39,6 +39,8 @@
     "test": "yarn clean:coverage && yarn test:ember && yarn test:finalize",
     "test:ember": "COVERAGE=true ember exam --test-port 0 --random",
     "test:finalize": "ember coverage-merge && yarn clean:coverage",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui",
     "deploy": "gh-pages -d dist",
     "postinstall": "patch-package",
     "prepare": "husky"
@@ -56,6 +58,7 @@
     "@glimmer/component": "^1.1.2",
     "@glimmer/tracking": "^1.1.2",
     "@mapbox/togeojson": "^0.16.2",
+    "@playwright/test": "^1.62.1",
     "Leaflet.vector-markers": "^0.0.6",
     "ajv": "^6.12.6",
     "ajv-errors": "^1.0.1",

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,0 +1,36 @@
+const { defineConfig, devices } = require('@playwright/test');
+
+/**
+ * Playwright requires Node 20+. The rest of this app's toolchain (ember-cli,
+ * the existing QUnit suite) is pinned to Node 18 - see package.json's
+ * "engines" field - so run e2e commands under a separate Node 20+ version
+ * (e.g. `nvm exec 20 yarn test:e2e`). This is a separate process from the
+ * Ember build either way, so the two toolchains don't need to share a
+ * Node version.
+ */
+module.exports = defineConfig({
+  testDir: './e2e',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: 'html',
+  use: {
+    baseURL: 'http://localhost:4200',
+    trace: 'on-first-retry',
+  },
+
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+
+  webServer: {
+    command: 'yarn start',
+    url: 'http://localhost:4200',
+    reuseExistingServer: !process.env.CI,
+    timeout: 120 * 1000,
+  },
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -3174,6 +3174,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@playwright/test@npm:^1.62.1":
+  version: 1.62.1
+  resolution: "@playwright/test@npm:1.62.1"
+  dependencies:
+    playwright: "npm:1.62.1"
+  bin:
+    playwright: cli.js
+  checksum: 10c0/4b76f2f717723f84a73601f74fde97f5d92e4b5c869cf87c0f5628bf247fa1d18c9dc6c8e136463303233239e8ce58f902513d4281a9fabc3c426e911ded2c83
+  languageName: node
+  linkType: hard
+
 "@prettier/sync@npm:^0.2.1":
   version: 0.2.1
   resolution: "@prettier/sync@npm:0.2.1"
@@ -12786,6 +12797,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fsevents@npm:2.3.2":
+  version: 2.3.2
+  resolution: "fsevents@npm:2.3.2"
+  dependencies:
+    node-gyp: "npm:latest"
+  checksum: 10c0/be78a3efa3e181cda3cf7a4637cb527bcebb0bd0ea0440105a3bb45b86f9245b307dc10a2507e8f4498a7d4ec349d1910f4d73e4d4495b16103106e07eee735b
+  conditions: os=darwin
+  languageName: node
+  linkType: hard
+
 "fsevents@npm:^1.2.7":
   version: 1.2.13
   resolution: "fsevents@npm:1.2.13"
@@ -12803,6 +12824,15 @@ __metadata:
   dependencies:
     node-gyp: "npm:latest"
   checksum: 10c0/a1f0c44595123ed717febbc478aa952e47adfc28e2092be66b8ab1635147254ca6cfe1df792a8997f22716d4cbafc73309899ff7bfac2ac3ad8cf2e4ecc3ec60
+  conditions: os=darwin
+  languageName: node
+  linkType: hard
+
+"fsevents@patch:fsevents@npm%3A2.3.2#optional!builtin<compat/fsevents>":
+  version: 2.3.2
+  resolution: "fsevents@patch:fsevents@npm%3A2.3.2#optional!builtin<compat/fsevents>::version=2.3.2&hash=df0bf1"
+  dependencies:
+    node-gyp: "npm:latest"
   conditions: os=darwin
   languageName: node
   linkType: hard
@@ -16751,6 +16781,7 @@ __metadata:
     "@glimmer/component": "npm:^1.1.2"
     "@glimmer/tracking": "npm:^1.1.2"
     "@mapbox/togeojson": "npm:^0.16.2"
+    "@playwright/test": "npm:^1.62.1"
     Leaflet.vector-markers: "npm:^0.0.6"
     ajv: "npm:^6.12.6"
     ajv-errors: "npm:^1.0.1"
@@ -19003,6 +19034,30 @@ __metadata:
   dependencies:
     find-up: "npm:^3.0.0"
   checksum: 10c0/ecb60e1f8e1f611c0bdf1a0b6a474d6dfb51185567dc6f29cdef37c8d480ecba5362e006606bb290519bbb6f49526c403fabea93c3090c20368d98bb90c999ab
+  languageName: node
+  linkType: hard
+
+"playwright-core@npm:1.62.1":
+  version: 1.62.1
+  resolution: "playwright-core@npm:1.62.1"
+  bin:
+    playwright-core: cli.js
+  checksum: 10c0/a37d0f03bb73364cfd0eba704c4b3359b609c4779ae2649a88d8e2b3a29c7357dfcc58bdcf0cb68ddffdef7687abf78902c8356e89f189682c7e19be38e108f0
+  languageName: node
+  linkType: hard
+
+"playwright@npm:1.62.1":
+  version: 1.62.1
+  resolution: "playwright@npm:1.62.1"
+  dependencies:
+    fsevents: "npm:2.3.2"
+    playwright-core: "npm:1.62.1"
+  dependenciesMeta:
+    fsevents:
+      optional: true
+  bin:
+    playwright: cli.js
+  checksum: 10c0/4d3522cd46325f50c46f8874d31f70d036f6983228a9f8b9d68fc249e4c17464edcd97cc4adfbb24e712d1829c1386d3bc24e17f58a1ced94e7c423300c21845
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Initial scaffolding to introduce [Playwright](https://playwright.dev/) as an end-to-end testing layer alongside the existing Ember/QUnit suite. No app code changes - this only adds the tooling and a couple of smoke tests to validate the setup works.

**Why Playwright, alongside (not replacing) the QUnit suite:** the existing suite covers component/service-level correctness well, but has essentially no true end-to-end coverage (`tests/acceptance/` has a single test) - several real bugs found during the recent Ember 4 migration work only surfaced via manual, full-browser verification, not the automated suite. Playwright drives a real browser against the actual running app rather than Ember's internal test build, which better exercises full user flows, and won't need to change in lockstep with future Ember/ember-qunit internals. The plan is to keep this scoped to a handful of critical flows (record create/edit/publish, import/export) rather than duplicate what the QUnit suite already covers well.

## What's included

- `@playwright/test` added as a dev dependency; Chromium browser installed
- `playwright.config.js` - `testDir: e2e/`, auto-starts/reuses the dev server (`yarn start`) via Playwright's `webServer` option, Chromium project only for now
- `e2e/smoke.spec.js` - two smoke tests (dashboard summary cards render, top nav links are present) to validate the scaffolding end-to-end
- `package.json` scripts: `test:e2e`, `test:e2e:ui`
- `.gitignore` entries for `playwright-report/` and `test-results/`

## Important gotcha

**Playwright requires Node 20+; this repo's `engines` field pins Node 18** for the existing ember-cli/QUnit toolchain. This PR does **not** change the root `engines` field - Playwright runs as a fully separate process from `ember serve`/`ember test`, so there's no actual conflict, but e2e commands need to be run under Node 20+ (e.g. `nvm exec 20 yarn test:e2e`). Documented as a comment at the top of `playwright.config.js`.

## Test plan

- [x] `nvm exec 20 yarn test:e2e` passes against a cold-started dev server
- [x] `nvm exec 20 yarn test:e2e` passes against an already-running dev server (webServer reuse)
- [ ] Decide on Node-version handling for CI before merging out of draft (bump CI's Node for this job, or pin an older `@playwright/test` release that supports Node 18)
- [ ] Flesh out real e2e coverage for at least one critical flow before merging out of draft

This PR is intentionally left as a draft - scaffolding only, not ready for real coverage/CI wiring yet.