### PR TITLE
chore: Setup Node 20

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,10 +22,10 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - name: Use Node.js 18
+      - name: Use Node.js 20
         uses: actions/setup-node@v5
         with:
-          node-version: '18'
+          node-version: '20'
           package-manager-cache: false
 
       # Must run before the cache-enabled setup-node below: that action shells
@@ -37,7 +37,7 @@ jobs:
       - name: Restore Yarn cache
         uses: actions/setup-node@v5
         with:
-          node-version: '18'
+          node-version: '20'
           cache: 'yarn'
           package-manager-cache: false
 
@@ -60,10 +60,10 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - name: Use Node.js 18
+      - name: Use Node.js 20
         uses: actions/setup-node@v5
         with:
-          node-version: '18'
+          node-version: '20'
           package-manager-cache: false
 
       # See note in the lint job: Corepack must be enabled before any
@@ -74,7 +74,7 @@ jobs:
       - name: Restore Yarn cache
         uses: actions/setup-node@v5
         with:
-          node-version: '18'
+          node-version: '20'
           cache: 'yarn'
           package-manager-cache: false
 

--- a/.github/workflows/gh-pages-deploy.yml
+++ b/.github/workflows/gh-pages-deploy.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v5
         with:
-          node-version: '18'
+          node-version: '20'
           package-manager-cache: false
 
       - name: enable corepack

--- a/README.md
+++ b/README.md
@@ -26,10 +26,10 @@ You will need the following things properly installed on your computer.
 
 - [Git][git]
 - [Node.js][node]
-  - Supported versions: `v18`.
+  - Supported versions: `v20`.
   - **Apple Silicon Users**:  if you experience problems building or running try Node v14.
   - We are now using Yarn V4. Here are the steps in setting it up.
-    - Make sure that you have Node Version 18 doesn't matter the minor semantic changes.
+    - Make sure that you have Node Version 20 doesn't matter the minor semantic changes.
     - Enable corepack by using the `corepack enable` command.
     - Remove `node_modules` folder
     - Run `yarn` to install packages again using Yarn V4.

--- a/package.json
+++ b/package.json
@@ -195,7 +195,7 @@
     "ember-gestures@npm:^1.1.1": "patch:ember-gestures@npm%3A1.1.5#~/.yarn/patches/ember-gestures-npm-1.1.5-4c127a6766.patch"
   },
   "engines": {
-    "node": "18*"
+    "node": "20*"
   },
   "ember": {
     "edition": "octane"


### PR DESCRIPTION
 - package.json: engines.node → "20*"
  - .github/workflows/ci.yml (4 spots) and gh-pages-deploy.yml (1 spot): Node 18 → 20
  - README.md: updated the two Node-version mentions (left the unrelated "Apple Silicon → try Node 14" troubleshooting note alone — different, unverified claim,
    out of scope)

  No yarn.lock changes needed — nothing had to move versions. Verified with a genuinely fresh yarn install under Node 20 (native modules rebuilt for the new ABI): lint (0 errors), production build, and the full test suite (528/528, 0 failures) all pass cleanly. 